### PR TITLE
feat(mq): implement ordered-reliable provider capability

### DIFF
--- a/pkg/server/event/mqbridge.go
+++ b/pkg/server/event/mqbridge.go
@@ -3,9 +3,13 @@ package event
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/digitalwayhk/core/pkg/server/mq"
 )
+
+// ErrOrderingKeyRequired 表示已声明 ordered-reliable 时 Envelope.ShardKey 为空。
+var ErrOrderingKeyRequired = errors.New("event: ordering key required")
 
 // MQBridge connects an in-process Stream to an external MQ provider, enabling
 // cross-service event delivery via message queues.
@@ -13,8 +17,9 @@ import (
 // Publish path:  event.Envelope → JSON → MQProvider.Publish
 // Subscribe path: MQProvider message → JSON → event.Envelope → Stream.Publish
 type MQBridge struct {
-	stream  *Stream
-	manager *mq.MQManager
+	stream                 *Stream
+	manager                *mq.MQManager
+	requireOrderedReliable bool
 }
 
 // NewMQBridge creates a bridge between the given Stream and MQManager.
@@ -22,13 +27,41 @@ func NewMQBridge(stream *Stream, manager *mq.MQManager) *MQBridge {
 	return &MQBridge{stream: stream, manager: manager}
 }
 
+// EnsureOrderedReliable 校验底层 provider 支持 ordered-reliable，并开启发布侧空 key 门禁。
+func (b *MQBridge) EnsureOrderedReliable() error {
+	if b == nil || b.manager == nil {
+		return mq.ErrOrderedReliableUnsupported
+	}
+	if err := b.manager.RequireOrderedReliable(); err != nil {
+		return err
+	}
+	b.requireOrderedReliable = true
+	return nil
+}
+
+// RequiresOrderedReliable 报告是否已开启 ordered-reliable 发布门禁。
+func (b *MQBridge) RequiresOrderedReliable() bool {
+	return b != nil && b.requireOrderedReliable
+}
+
 // Publish serialises env to JSON and delivers it to the MQ provider on subject.
+// IdempotencyKey 与 ShardKey 透传为 PublishOptions，供 provider 做 dedup 与分区。
 func (b *MQBridge) Publish(ctx context.Context, subject string, env *Envelope) error {
+	if env == nil {
+		return ErrInvalidPublishRequest
+	}
+	if b.requireOrderedReliable && env.ShardKey == "" {
+		return ErrOrderingKeyRequired
+	}
 	data, err := json.Marshal(env)
 	if err != nil {
 		return err
 	}
-	return b.manager.Publish(ctx, subject, data, nil)
+	opts := &mq.PublishOptions{
+		IdempotencyKey: env.IdempotencyKey,
+		OrderingKey:    env.ShardKey,
+	}
+	return b.manager.Publish(ctx, subject, data, opts)
 }
 
 // Subscribe registers an MQ subscription on subject. Each incoming MQ message
@@ -53,7 +86,7 @@ func (b *MQBridge) Subscribe(ctx context.Context, subject string) (cancel func()
 }
 
 // SubscribeReliable 使用逻辑服务名作为 consumer group，只有全部控制 Handler
-// 成功后 Redis Provider 才确认消息。
+// 成功后 Provider 才确认消息。
 func (b *MQBridge) SubscribeReliable(ctx context.Context, subject, subscriberID string) (func(), error) {
 	return b.manager.SubscribeReliable(ctx, subject, mq.ReliableSubscribeOptions{Group: subscriberID}, func(msg *mq.Message) error {
 		env := &Envelope{}

--- a/pkg/server/event/mqbridge_test.go
+++ b/pkg/server/event/mqbridge_test.go
@@ -26,6 +26,7 @@ type fakeMQProvider struct {
 type fakeMsg struct {
 	subject string
 	data    []byte
+	opts    *mq.PublishOptions
 }
 
 func (f *fakeMQProvider) Name() string                    { return "fake" }
@@ -33,9 +34,14 @@ func (f *fakeMQProvider) Connect(_ context.Context) error { return nil }
 func (f *fakeMQProvider) Close() error                    { return nil }
 func (f *fakeMQProvider) Health(_ context.Context) error  { return nil }
 
-func (f *fakeMQProvider) Publish(_ context.Context, subject string, data []byte, _ *mq.PublishOptions) error {
+func (f *fakeMQProvider) Publish(_ context.Context, subject string, data []byte, opts *mq.PublishOptions) error {
 	f.mu.Lock()
-	f.published = append(f.published, fakeMsg{subject, data})
+	var optsCopy *mq.PublishOptions
+	if opts != nil {
+		cp := *opts
+		optsCopy = &cp
+	}
+	f.published = append(f.published, fakeMsg{subject: subject, data: data, opts: optsCopy})
 	h := f.handler
 	f.mu.Unlock()
 
@@ -84,6 +90,8 @@ func TestMQBridge_Publish_SerializesEnvelopeToMQ(t *testing.T) {
 
 	env := event.NewEnvelope("svc.test", "order.created", []byte(`{"id":1}`))
 	env.TraceID = "trace-xyz"
+	env.IdempotencyKey = "idem-1"
+	env.ShardKey = "user-9"
 
 	ctx := context.Background()
 	require.NoError(t, bridge.Publish(ctx, "order.events", env))
@@ -94,6 +102,9 @@ func TestMQBridge_Publish_SerializesEnvelopeToMQ(t *testing.T) {
 
 	require.Len(t, published, 1, "one message should be published to MQ")
 	assert.Equal(t, "order.events", published[0].subject)
+	require.NotNil(t, published[0].opts)
+	assert.Equal(t, "idem-1", published[0].opts.IdempotencyKey)
+	assert.Equal(t, "user-9", published[0].opts.OrderingKey)
 
 	var got event.Envelope
 	require.NoError(t, json.Unmarshal(published[0].data, &got))
@@ -102,6 +113,20 @@ func TestMQBridge_Publish_SerializesEnvelopeToMQ(t *testing.T) {
 	assert.Equal(t, env.Source, got.Source)
 	assert.Equal(t, env.TraceID, got.TraceID)
 	assert.Equal(t, env.Data, got.Data)
+}
+
+func TestMQBridge_Publish_RequireOrderedRejectsEmptyShardKey(t *testing.T) {
+	stream := event.NewStream()
+	provider := mq.NewFakeOrderedReliableProvider()
+	mgr := mq.NewManager()
+	mgr.Register(provider)
+	require.NoError(t, mgr.SetCurrent(provider.Name()))
+	bridge := event.NewMQBridge(stream, mgr)
+	require.NoError(t, bridge.EnsureOrderedReliable())
+
+	env := event.NewEnvelope("svc.test", "order.created", []byte(`{}`))
+	err := bridge.Publish(context.Background(), "order.events", env)
+	require.ErrorIs(t, err, event.ErrOrderingKeyRequired)
 }
 
 // TestMQBridge_Subscribe_DeserializesAndDeliversToStream verifies that an MQ

--- a/pkg/server/event/ordered_reliable_require_test.go
+++ b/pkg/server/event/ordered_reliable_require_test.go
@@ -1,0 +1,81 @@
+package event_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/digitalwayhk/core/pkg/server/event"
+	"github.com/digitalwayhk/core/pkg/server/mq"
+	"github.com/stretchr/testify/require"
+)
+
+type plainExternal struct{}
+
+func (*plainExternal) Publish(context.Context, string, *event.Envelope) error { return nil }
+
+func TestRequireOrderedReliableFailClosedWithoutExternal(t *testing.T) {
+	bridge := event.NewServiceEventBridge(event.NewStream(), event.ServiceEventBridgeOptions{
+		SubscriberID: "svc",
+	})
+	err := bridge.RequireOrderedReliableByShardKey()
+	require.ErrorIs(t, err, event.ErrExternalProviderUnavailable)
+	require.False(t, bridge.RequiresOrderedReliable())
+}
+
+func TestRequireOrderedReliableFailClosedWithoutCapability(t *testing.T) {
+	bridge := event.NewServiceEventBridge(event.NewStream(), event.ServiceEventBridgeOptions{
+		SubscriberID: "svc",
+	})
+	bridge.SetExternalPublisher(&plainExternal{})
+	err := bridge.RequireOrderedReliableByShardKey()
+	require.ErrorIs(t, err, event.ErrOrderedReliableUnsupported)
+	require.False(t, bridge.RequiresOrderedReliable())
+}
+
+func TestRequireOrderedReliableEmptyShardKeyRejectedOnExternalPublish(t *testing.T) {
+	stream := event.NewStream()
+	provider := mq.NewFakeOrderedReliableProvider()
+	mgr := mq.NewManager()
+	mgr.Register(provider)
+	require.NoError(t, mgr.SetCurrent(provider.Name()))
+	mqBridge := event.NewMQBridge(stream, mgr)
+
+	bridge := event.NewServiceEventBridge(stream, event.ServiceEventBridgeOptions{SubscriberID: "svc"})
+	bridge.SetExternalPublisher(mqBridge)
+	require.NoError(t, bridge.RequireOrderedReliableByShardKey())
+	require.True(t, bridge.RequiresOrderedReliable())
+
+	env := event.NewEnvelope("svc", "fill", []byte(`{}`))
+	err := bridge.Publish(context.Background(), event.PublishRequest{
+		Class:    event.ControlDelivery,
+		External: true,
+		Subject:  "fills",
+		Envelope: env,
+	})
+	require.ErrorIs(t, err, event.ErrOrderingKeyRequired)
+
+	env.ShardKey = "market-a"
+	require.NoError(t, bridge.Publish(context.Background(), event.PublishRequest{
+		Class:    event.ControlDelivery,
+		External: true,
+		Subject:  "fills",
+		Envelope: env,
+	}))
+}
+
+func TestRequireOrderedReliableOptionDefersUntilExternalEnsured(t *testing.T) {
+	stream := event.NewStream()
+	// 仅构造选项不能在无 provider 校验时开启门禁。
+	bridge := event.NewServiceEventBridge(stream, event.ServiceEventBridgeOptions{
+		SubscriberID:                     "svc",
+		RequireOrderedReliableByShardKey: true,
+	})
+	require.False(t, bridge.RequiresOrderedReliable())
+
+	provider := mq.NewFakeOrderedReliableProvider()
+	mgr := mq.NewManager()
+	mgr.Register(provider)
+	require.NoError(t, mgr.SetCurrent(provider.Name()))
+	bridge.SetExternalPublisher(event.NewMQBridge(stream, mgr))
+	require.True(t, bridge.RequiresOrderedReliable())
+}

--- a/pkg/server/event/outbox.go
+++ b/pkg/server/event/outbox.go
@@ -93,6 +93,9 @@ func (p *outboxPublisher) run(ctx context.Context) {
 }
 
 func (p *outboxPublisher) drain(ctx context.Context) {
+	// 本轮同 OrderingKey 失败屏障：最早失败的 key 阻断后续同 key 记录，其他 key 可继续。
+	// 屏障仅用于本轮 drain；跨重启依赖 LoadPending 仍返回 earliest unpublished。
+	blocked := make(map[string]struct{})
 	for {
 		items, err := p.store.LoadPending(ctx, p.batch)
 		if err != nil {
@@ -102,19 +105,39 @@ func (p *outboxPublisher) drain(ctx context.Context) {
 		if len(items) == 0 {
 			return
 		}
+		progressed := false
 		for _, item := range items {
+			key := outboxOrderingKey(item)
+			if _, skip := blocked[key]; skip {
+				continue
+			}
 			if err := p.publish(ctx, item); err != nil {
-				logx.Errorw("event_outbox_publish_failed", logx.Field("service", p.source), logx.Field("event_type", item.EventType), logx.Field("event_id", item.EventID), logx.Field("error", err))
+				logx.Errorw("event_outbox_publish_failed", logx.Field("service", p.source), logx.Field("event_type", item.EventType), logx.Field("event_id", item.EventID), logx.Field("ordering_key", key), logx.Field("error", err))
+				blocked[key] = struct{}{}
 				continue
 			}
 			if err := p.store.MarkPublished(ctx, item); err != nil {
 				logx.Errorw("event_outbox_mark_failed", logx.Field("service", p.source), logx.Field("event_type", item.EventType), logx.Field("event_id", item.EventID), logx.Field("error", err))
+				// Mark 失败允许同 EventID 重发；本轮仍阻断同 key，避免后续记录抢先发布。
+				blocked[key] = struct{}{}
+				continue
 			}
+			progressed = true
 		}
-		if len(items) < p.batch {
+		if len(items) < p.batch || !progressed {
 			return
 		}
 	}
+}
+
+func outboxOrderingKey(item OutboxMessage) string {
+	if item.ShardKey != "" {
+		return item.ShardKey
+	}
+	if item.EventID != "" {
+		return item.EventType + ":" + item.EventID
+	}
+	return item.EventType + ":unknown"
 }
 
 func (p *outboxPublisher) publish(ctx context.Context, item OutboxMessage) error {
@@ -130,6 +153,9 @@ func (p *outboxPublisher) publish(ctx context.Context, item OutboxMessage) error
 	}
 	env.ShardKey = item.ShardKey
 	if env.ShardKey == "" {
+		if p.bridge != nil && p.bridge.RequiresOrderedReliable() {
+			return ErrOrderingKeyRequired
+		}
 		env.ShardKey = item.EventType + ":" + env.ID
 	}
 	return p.bridge.Publish(ctx, PublishRequest{Class: ControlDelivery, External: p.external, Subject: item.Subject, Envelope: env})

--- a/pkg/server/event/outbox_barrier_test.go
+++ b/pkg/server/event/outbox_barrier_test.go
@@ -1,0 +1,91 @@
+package event_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitalwayhk/core/pkg/server/event"
+	"github.com/stretchr/testify/require"
+)
+
+type barrierStore struct {
+	mu      sync.Mutex
+	pending []event.OutboxMessage
+	marked  []string
+}
+
+func (s *barrierStore) LoadPending(_ context.Context, limit int) ([]event.OutboxMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if limit > len(s.pending) {
+		limit = len(s.pending)
+	}
+	out := make([]event.OutboxMessage, limit)
+	copy(out, s.pending[:limit])
+	return out, nil
+}
+
+func (s *barrierStore) MarkPublished(_ context.Context, message event.OutboxMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.marked = append(s.marked, message.EventID)
+	next := s.pending[:0]
+	for _, item := range s.pending {
+		if item.EventID != message.EventID {
+			next = append(next, item)
+		}
+	}
+	s.pending = next
+	return nil
+}
+
+type barrierExternal struct {
+	mu        sync.Mutex
+	failID    string
+	published []string
+}
+
+func (e *barrierExternal) Publish(_ context.Context, _ string, env *event.Envelope) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if env.ID == e.failID {
+		return errors.New("publish failed")
+	}
+	e.published = append(e.published, env.ID)
+	return nil
+}
+
+func TestOutboxSameKeyFailureBarrierAllowsOtherKeys(t *testing.T) {
+	stream := event.NewStream()
+	bridge := event.NewServiceEventBridge(stream, event.ServiceEventBridgeOptions{SubscriberID: "svc"})
+	external := &barrierExternal{failID: "a2"}
+	bridge.SetExternalPublisher(external)
+	store := &barrierStore{pending: []event.OutboxMessage{
+		{EventID: "a1", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a1")},
+		{EventID: "a2", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a2")},
+		{EventID: "a3", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a3")},
+		{EventID: "b1", EventType: "fill", Subject: "fills", ShardKey: "market-b", Payload: []byte("b1")},
+	}}
+	require.NoError(t, bridge.UseOutbox(event.OutboxOptions{
+		SourceService: "trades",
+		Store:         store,
+		Interval:      time.Hour,
+		BatchSize:     10,
+		External:      true,
+	}))
+	bridge.NotifyOutbox()
+	time.Sleep(150 * time.Millisecond)
+
+	external.mu.Lock()
+	published := append([]string(nil), external.published...)
+	external.mu.Unlock()
+	require.Equal(t, []string{"a1", "b1"}, published)
+
+	store.mu.Lock()
+	marked := append([]string(nil), store.marked...)
+	store.mu.Unlock()
+	require.Equal(t, []string{"a1", "b1"}, marked)
+}

--- a/pkg/server/event/servicebridge.go
+++ b/pkg/server/event/servicebridge.go
@@ -84,16 +84,19 @@ type ServiceEventBridge struct {
 	closed atomic.Bool
 	once   sync.Once
 
-	externalMu             sync.RWMutex
-	external               ExternalPublisher
-	subscriber             ExternalSubscriber
-	reliableSubscriber     ReliableExternalSubscriber
-	externalSubMu          sync.Mutex
-	externalSubscriptions  map[string]*externalSubscriptionRef
-	outboxMu               sync.Mutex
-	outbox                 *outboxPublisher
-	subscriberID           string
-	requireOrderedReliable bool
+	externalMu            sync.RWMutex
+	external              ExternalPublisher
+	subscriber            ExternalSubscriber
+	reliableSubscriber    ReliableExternalSubscriber
+	externalSubMu         sync.Mutex
+	externalSubscriptions map[string]*externalSubscriptionRef
+	outboxMu              sync.Mutex
+	outbox                *outboxPublisher
+	subscriberID          string
+	// wantOrderedReliable 来自构造选项，表示意图；真正开启门禁必须 Ensure 成功。
+	wantOrderedReliable bool
+	// requireOrderedReliable 仅在 EnsureOrderedReliable 成功后置位。
+	requireOrderedReliable atomic.Bool
 	dropped                atomic.Uint64
 	controlQueueTimeouts   atomic.Uint64
 }
@@ -116,14 +119,14 @@ func NewServiceEventBridge(stream *Stream, options ServiceEventBridgeOptions) *S
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	b := &ServiceEventBridge{
-		stream:                 stream,
-		observerQueue:          make(chan PublishRequest, options.ObserverQueueSize),
-		controlQueues:          make([]chan controlEvent, options.ControlShards),
-		controlTimeout:         options.ControlEnqueueTimeout,
-		subscriberID:           options.SubscriberID,
-		requireOrderedReliable: options.RequireOrderedReliableByShardKey,
-		ctx:                    ctx,
-		cancel:                 cancel,
+		stream:              stream,
+		observerQueue:       make(chan PublishRequest, options.ObserverQueueSize),
+		controlQueues:       make([]chan controlEvent, options.ControlShards),
+		controlTimeout:      options.ControlEnqueueTimeout,
+		subscriberID:        options.SubscriberID,
+		wantOrderedReliable: options.RequireOrderedReliableByShardKey,
+		ctx:                 ctx,
+		cancel:              cancel,
 	}
 	b.wg.Add(1)
 	go b.runObserver()
@@ -150,7 +153,12 @@ func (b *ServiceEventBridge) SetExternalPublisher(publisher ExternalPublisher) {
 	b.external = publisher
 	b.subscriber, _ = publisher.(ExternalSubscriber)
 	b.reliableSubscriber, _ = publisher.(ReliableExternalSubscriber)
+	want := b.wantOrderedReliable
 	b.externalMu.Unlock()
+	// 构造时声明了 requirement：装配外部适配器后立即 Ensure，失败则保持未开启（后续 Publish/Require 仍 fail closed）。
+	if want && publisher != nil {
+		_ = b.ensureOrderedReliableOn(publisher)
+	}
 }
 
 // RequireOrderedReliableByShardKey 声明本服务控制事件需要 ordered-reliable 能力。
@@ -159,29 +167,36 @@ func (b *ServiceEventBridge) RequireOrderedReliableByShardKey() error {
 	if b == nil || b.closed.Load() {
 		return ErrServiceEventBridgeClosed
 	}
-	b.externalMu.RLock()
+	b.externalMu.Lock()
+	b.wantOrderedReliable = true
 	publisher := b.external
-	b.externalMu.RUnlock()
+	b.externalMu.Unlock()
 	if publisher == nil {
 		return ErrExternalProviderUnavailable
 	}
+	return b.ensureOrderedReliableOn(publisher)
+}
+
+func (b *ServiceEventBridge) ensureOrderedReliableOn(publisher ExternalPublisher) error {
 	ensurer, ok := publisher.(orderedReliableEnsurer)
 	if !ok {
+		b.requireOrderedReliable.Store(false)
 		return ErrOrderedReliableUnsupported
 	}
 	if err := ensurer.EnsureOrderedReliable(); err != nil {
+		b.requireOrderedReliable.Store(false)
 		return err
 	}
-	b.requireOrderedReliable = true
+	b.requireOrderedReliable.Store(true)
 	return nil
 }
 
-// RequiresOrderedReliable 报告是否已声明 ordered-reliable 需求。
+// RequiresOrderedReliable 报告是否已成功开启 ordered-reliable 发布门禁。
 func (b *ServiceEventBridge) RequiresOrderedReliable() bool {
 	if b == nil {
 		return false
 	}
-	if b.requireOrderedReliable {
+	if b.requireOrderedReliable.Load() {
 		return true
 	}
 	b.externalMu.RLock()

--- a/pkg/server/event/servicebridge.go
+++ b/pkg/server/event/servicebridge.go
@@ -14,7 +14,14 @@ var (
 	ErrServiceEventBridgeClosed    = errors.New("service event bridge closed")
 	ErrInvalidPublishRequest       = errors.New("invalid event publish request")
 	ErrControlQueueTimeout         = errors.New("service event bridge control queue timeout")
+	ErrOrderedReliableUnsupported  = errors.New("event ordered reliable unsupported")
 )
+
+// orderedReliableEnsurer 由外部适配器（如 MQBridge）实现，用于启动 fail-closed 检查。
+type orderedReliableEnsurer interface {
+	EnsureOrderedReliable() error
+	RequiresOrderedReliable() bool
+}
 
 const defaultControlEnqueueTimeout = 5 * time.Second
 
@@ -48,11 +55,12 @@ type ReliableExternalSubscriber interface {
 }
 
 type ServiceEventBridgeOptions struct {
-	ObserverQueueSize     int
-	ControlQueueSize      int
-	ControlShards         int
-	ControlEnqueueTimeout time.Duration
-	SubscriberID          string
+	ObserverQueueSize                int
+	ControlQueueSize                 int
+	ControlShards                    int
+	ControlEnqueueTimeout            time.Duration
+	SubscriberID                     string
+	RequireOrderedReliableByShardKey bool
 }
 
 type controlEvent struct {
@@ -76,17 +84,18 @@ type ServiceEventBridge struct {
 	closed atomic.Bool
 	once   sync.Once
 
-	externalMu            sync.RWMutex
-	external              ExternalPublisher
-	subscriber            ExternalSubscriber
-	reliableSubscriber    ReliableExternalSubscriber
-	externalSubMu         sync.Mutex
-	externalSubscriptions map[string]*externalSubscriptionRef
-	outboxMu              sync.Mutex
-	outbox                *outboxPublisher
-	subscriberID          string
-	dropped               atomic.Uint64
-	controlQueueTimeouts  atomic.Uint64
+	externalMu             sync.RWMutex
+	external               ExternalPublisher
+	subscriber             ExternalSubscriber
+	reliableSubscriber     ReliableExternalSubscriber
+	externalSubMu          sync.Mutex
+	externalSubscriptions  map[string]*externalSubscriptionRef
+	outboxMu               sync.Mutex
+	outbox                 *outboxPublisher
+	subscriberID           string
+	requireOrderedReliable bool
+	dropped                atomic.Uint64
+	controlQueueTimeouts   atomic.Uint64
 }
 
 func NewServiceEventBridge(stream *Stream, options ServiceEventBridgeOptions) *ServiceEventBridge {
@@ -107,13 +116,14 @@ func NewServiceEventBridge(stream *Stream, options ServiceEventBridgeOptions) *S
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	b := &ServiceEventBridge{
-		stream:         stream,
-		observerQueue:  make(chan PublishRequest, options.ObserverQueueSize),
-		controlQueues:  make([]chan controlEvent, options.ControlShards),
-		controlTimeout: options.ControlEnqueueTimeout,
-		subscriberID:   options.SubscriberID,
-		ctx:            ctx,
-		cancel:         cancel,
+		stream:                 stream,
+		observerQueue:          make(chan PublishRequest, options.ObserverQueueSize),
+		controlQueues:          make([]chan controlEvent, options.ControlShards),
+		controlTimeout:         options.ControlEnqueueTimeout,
+		subscriberID:           options.SubscriberID,
+		requireOrderedReliable: options.RequireOrderedReliableByShardKey,
+		ctx:                    ctx,
+		cancel:                 cancel,
 	}
 	b.wg.Add(1)
 	go b.runObserver()
@@ -141,6 +151,46 @@ func (b *ServiceEventBridge) SetExternalPublisher(publisher ExternalPublisher) {
 	b.subscriber, _ = publisher.(ExternalSubscriber)
 	b.reliableSubscriber, _ = publisher.(ReliableExternalSubscriber)
 	b.externalMu.Unlock()
+}
+
+// RequireOrderedReliableByShardKey 声明本服务控制事件需要 ordered-reliable 能力。
+// provider 不具备能力、未装配外部适配器时 fail closed；成功后开启空 ShardKey 发布门禁。
+func (b *ServiceEventBridge) RequireOrderedReliableByShardKey() error {
+	if b == nil || b.closed.Load() {
+		return ErrServiceEventBridgeClosed
+	}
+	b.externalMu.RLock()
+	publisher := b.external
+	b.externalMu.RUnlock()
+	if publisher == nil {
+		return ErrExternalProviderUnavailable
+	}
+	ensurer, ok := publisher.(orderedReliableEnsurer)
+	if !ok {
+		return ErrOrderedReliableUnsupported
+	}
+	if err := ensurer.EnsureOrderedReliable(); err != nil {
+		return err
+	}
+	b.requireOrderedReliable = true
+	return nil
+}
+
+// RequiresOrderedReliable 报告是否已声明 ordered-reliable 需求。
+func (b *ServiceEventBridge) RequiresOrderedReliable() bool {
+	if b == nil {
+		return false
+	}
+	if b.requireOrderedReliable {
+		return true
+	}
+	b.externalMu.RLock()
+	publisher := b.external
+	b.externalMu.RUnlock()
+	if ensurer, ok := publisher.(orderedReliableEnsurer); ok {
+		return ensurer.RequiresOrderedReliable()
+	}
+	return false
 }
 
 func (b *ServiceEventBridge) HasExternalPublisher() bool {
@@ -276,6 +326,9 @@ func (b *ServiceEventBridge) Publish(ctx context.Context, request PublishRequest
 	}
 	if request.External && b.externalPublisher() == nil {
 		return ErrExternalProviderUnavailable
+	}
+	if request.External && b.RequiresOrderedReliable() && request.Envelope.ShardKey == "" {
+		return ErrOrderingKeyRequired
 	}
 	if request.Class == ObserverDelivery {
 		if !request.External && b.stream.SubscriberCount(request.Envelope.Type) == 0 {

--- a/pkg/server/mq/manager.go
+++ b/pkg/server/mq/manager.go
@@ -162,3 +162,27 @@ func (m *MQManager) SubscribeReliable(
 	}
 	return provider.SubscribeReliable(ctx, subject, options, handler)
 }
+
+// OrderedReliableInfo 返回当前 provider 的 ordered-reliable 声明；未实现则 ok=false。
+func (m *MQManager) OrderedReliableInfo() (OrderedReliableCapability, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.closed || m.current == nil {
+		return OrderedReliableCapability{}, false
+	}
+	provider, ok := m.current.(OrderedReliableMQProvider)
+	if !ok {
+		return OrderedReliableCapability{}, false
+	}
+	info := provider.OrderedReliableInfo()
+	return info, info.Valid()
+}
+
+// RequireOrderedReliable 校验当前 provider 已声明并具备合法的 ordered-reliable 能力。
+func (m *MQManager) RequireOrderedReliable() error {
+	info, ok := m.OrderedReliableInfo()
+	if !ok || !info.Valid() {
+		return ErrOrderedReliableUnsupported
+	}
+	return nil
+}

--- a/pkg/server/mq/mq.go
+++ b/pkg/server/mq/mq.go
@@ -14,6 +14,21 @@ var ErrNotConnected = errors.New("mq: provider not connected")
 
 var ErrReliableSubscribeUnsupported = errors.New("mq: reliable subscribe unsupported")
 
+// ErrOrderedReliableUnsupported 表示当前 provider 未声明或不满足 ordered-reliable 契约。
+var ErrOrderedReliableUnsupported = errors.New("mq: ordered reliable unsupported")
+
+// ErrOrderingKeyRequired 表示已要求 ordered-reliable 时发布缺少 OrderingKey。
+var ErrOrderingKeyRequired = errors.New("mq: ordering key required")
+
+// Ordered-reliable capability 固定取值。
+const (
+	DeliveryAtLeastOnce       = "AT_LEAST_ONCE"
+	OrderingScopeKey          = "ORDERING_KEY"
+	AckAfterHandlerSuccess    = "AFTER_HANDLER_SUCCESS"
+	FailurePolicyBlockSameKey = "BLOCK_SAME_KEY"
+	FailoverPolicyKeepOrder   = "KEEP_KEY_ORDER"
+)
+
 // Message is a single message received from the queue.
 type Message struct {
 	ID      string
@@ -29,6 +44,38 @@ type PublishOptions struct {
 	Subject string
 	// IdempotencyKey deduplicates messages at the broker level when supported.
 	IdempotencyKey string
+	// OrderingKey 声明业务分区/顺序键；零值保持现有无序或非按 key 行为。
+	OrderingKey string
+}
+
+// OrderedReliableCapability 描述 provider 的 ordered-reliable 行为声明。
+// 仅声明不够，必须通过 conformance suite 证明实际行为。
+type OrderedReliableCapability struct {
+	Delivery       string
+	OrderingScope  string
+	AckPolicy      string
+	FailurePolicy  string
+	FailoverPolicy string
+}
+
+// DefaultOrderedReliableCapability 返回标准 at-least-once + 同 key 失败阻断声明。
+func DefaultOrderedReliableCapability() OrderedReliableCapability {
+	return OrderedReliableCapability{
+		Delivery:       DeliveryAtLeastOnce,
+		OrderingScope:  OrderingScopeKey,
+		AckPolicy:      AckAfterHandlerSuccess,
+		FailurePolicy:  FailurePolicyBlockSameKey,
+		FailoverPolicy: FailoverPolicyKeepOrder,
+	}
+}
+
+// Valid 检查能力声明字段是否完整且取值合法。
+func (c OrderedReliableCapability) Valid() bool {
+	return c.Delivery == DeliveryAtLeastOnce &&
+		c.OrderingScope == OrderingScopeKey &&
+		c.AckPolicy == AckAfterHandlerSuccess &&
+		c.FailurePolicy == FailurePolicyBlockSameKey &&
+		c.FailoverPolicy == FailoverPolicyKeepOrder
 }
 
 // ReliableSubscribeOptions 为可靠消费提供稳定的服务组和实例消费者身份。
@@ -49,6 +96,13 @@ type ReliableMQProvider interface {
 		options ReliableSubscribeOptions,
 		handler func(msg *Message) error,
 	) (cancel func(), err error)
+}
+
+// OrderedReliableMQProvider 是可选扩展：在可靠 ACK 之上保证同 OrderingKey 有序与失败阻断。
+// 启动检查可做类型断言与 Info 合法性校验；行为以 conformance suite 为准。
+type OrderedReliableMQProvider interface {
+	ReliableMQProvider
+	OrderedReliableInfo() OrderedReliableCapability
 }
 
 // MQProvider is the interface that every message-queue backend must implement.

--- a/pkg/server/mq/ordered_reliable_fake.go
+++ b/pkg/server/mq/ordered_reliable_fake.go
@@ -1,0 +1,141 @@
+package mq
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// FakeOrderedReliableProvider 是 provider-neutral ordered-reliable 验收用内存实现。
+// 同 OrderingKey 串行且失败阻断；不同 key 可并行。
+type FakeOrderedReliableProvider struct {
+	mu       sync.Mutex
+	subs     map[string][]*fakeOrderedSub
+	queues   map[string][]fakeOrderedMsg // key = subject + "\x00" + orderingKey
+	inflight map[string]bool
+	seq      int
+}
+
+type fakeOrderedMsg struct {
+	id          string
+	subject     string
+	data        []byte
+	orderingKey string
+}
+
+type fakeOrderedSub struct {
+	group   string
+	handler func(*Message) error
+}
+
+// NewFakeOrderedReliableProvider 构造空 fake provider。
+func NewFakeOrderedReliableProvider() *FakeOrderedReliableProvider {
+	return &FakeOrderedReliableProvider{
+		subs:     make(map[string][]*fakeOrderedSub),
+		queues:   make(map[string][]fakeOrderedMsg),
+		inflight: make(map[string]bool),
+	}
+}
+
+func (f *FakeOrderedReliableProvider) Name() string                  { return "fake-ordered-reliable" }
+func (f *FakeOrderedReliableProvider) Connect(context.Context) error { return nil }
+func (f *FakeOrderedReliableProvider) Close() error                  { return nil }
+func (f *FakeOrderedReliableProvider) Health(context.Context) error  { return nil }
+func (f *FakeOrderedReliableProvider) OrderedReliableInfo() OrderedReliableCapability {
+	return DefaultOrderedReliableCapability()
+}
+
+func (f *FakeOrderedReliableProvider) Publish(_ context.Context, subject string, data []byte, opts *PublishOptions) error {
+	orderingKey := "_default"
+	idem := ""
+	if opts != nil {
+		if opts.OrderingKey != "" {
+			orderingKey = opts.OrderingKey
+		}
+		idem = opts.IdempotencyKey
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq++
+	id := idem
+	if id == "" {
+		id = time.Now().Format("150405.000000") + ":" + string(rune('a'+f.seq%26))
+	}
+	qkey := subject + "\x00" + orderingKey
+	f.queues[qkey] = append(f.queues[qkey], fakeOrderedMsg{
+		id: id, subject: subject, data: append([]byte(nil), data...), orderingKey: orderingKey,
+	})
+	f.dispatchLocked(subject, orderingKey)
+	return nil
+}
+
+func (f *FakeOrderedReliableProvider) Subscribe(context.Context, string, func(*Message)) (func(), error) {
+	return func() {}, nil
+}
+
+func (f *FakeOrderedReliableProvider) SubscribeReliable(
+	_ context.Context,
+	subject string,
+	options ReliableSubscribeOptions,
+	handler func(*Message) error,
+) (func(), error) {
+	if handler == nil || options.Group == "" {
+		return nil, ErrReliableSubscribeUnsupported
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sub := &fakeOrderedSub{group: options.Group, handler: handler}
+	f.subs[subject] = append(f.subs[subject], sub)
+	for qkey := range f.queues {
+		if len(qkey) > len(subject) && qkey[:len(subject)] == subject && qkey[len(subject)] == 0 {
+			f.dispatchLocked(subject, qkey[len(subject)+1:])
+		}
+	}
+	return func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		list := f.subs[subject]
+		out := list[:0]
+		for _, item := range list {
+			if item != sub {
+				out = append(out, item)
+			}
+		}
+		f.subs[subject] = out
+	}, nil
+}
+
+func (f *FakeOrderedReliableProvider) dispatchLocked(subject, orderingKey string) {
+	qkey := subject + "\x00" + orderingKey
+	if f.inflight[qkey] || len(f.queues[qkey]) == 0 || len(f.subs[subject]) == 0 {
+		return
+	}
+	msg := f.queues[qkey][0]
+	handler := f.subs[subject][0].handler
+	f.inflight[qkey] = true
+	go func() {
+		message := &Message{
+			ID:      msg.id,
+			Subject: msg.subject,
+			Data:    msg.data,
+			Ack:     func() error { return nil },
+		}
+		err := handler(message)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.inflight[qkey] = false
+		if err != nil {
+			// 失败阻断：保留队头，短暂后重试（模拟 pending redelivery）。
+			time.AfterFunc(20*time.Millisecond, func() {
+				f.mu.Lock()
+				defer f.mu.Unlock()
+				f.dispatchLocked(subject, orderingKey)
+			})
+			return
+		}
+		if len(f.queues[qkey]) > 0 && f.queues[qkey][0].id == msg.id {
+			f.queues[qkey] = f.queues[qkey][1:]
+		}
+		f.dispatchLocked(subject, orderingKey)
+	}()
+}

--- a/pkg/server/mq/ordered_reliable_test.go
+++ b/pkg/server/mq/ordered_reliable_test.go
@@ -1,0 +1,128 @@
+package mq_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitalwayhk/core/pkg/server/mq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeOrderedReliableSameKeyStrictOrderAndFailureBarrier(t *testing.T) {
+	provider := mq.NewFakeOrderedReliableProvider()
+	require.True(t, provider.OrderedReliableInfo().Valid())
+
+	var (
+		mu        sync.Mutex
+		got       []string
+		allowM3   atomic.Bool
+		m3Fails   atomic.Int32
+		completed = make(chan struct{})
+	)
+	cancel, err := provider.SubscribeReliable(context.Background(), "fills", mq.ReliableSubscribeOptions{Group: "positions"}, func(msg *mq.Message) error {
+		body := string(msg.Data)
+		if body == "m3" && !allowM3.Load() {
+			m3Fails.Add(1)
+			return errors.New("boom")
+		}
+		mu.Lock()
+		got = append(got, body)
+		n := len(got)
+		mu.Unlock()
+		if n == 5 {
+			close(completed)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	defer cancel()
+
+	ctx := context.Background()
+	for _, body := range []string{"m1", "m2", "m3", "m4", "m5"} {
+		require.NoError(t, provider.Publish(ctx, "fills", []byte(body), &mq.PublishOptions{
+			OrderingKey: "market-a", IdempotencyKey: body,
+		}))
+	}
+
+	// 失败阻断窗口：m3 持续失败时，m4/m5 不得执行
+	time.Sleep(120 * time.Millisecond)
+	mu.Lock()
+	require.Equal(t, []string{"m1", "m2"}, got)
+	mu.Unlock()
+	require.GreaterOrEqual(t, m3Fails.Load(), int32(1))
+
+	allowM3.Store(true)
+	select {
+	case <-completed:
+	case <-time.After(2 * time.Second):
+		mu.Lock()
+		t.Fatalf("timeout got=%v", got)
+	}
+	mu.Lock()
+	require.Equal(t, []string{"m1", "m2", "m3", "m4", "m5"}, got)
+	mu.Unlock()
+}
+
+func TestFakeOrderedReliableDifferentKeysParallel(t *testing.T) {
+	provider := mq.NewFakeOrderedReliableProvider()
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	_, err := provider.SubscribeReliable(context.Background(), "fills", mq.ReliableSubscribeOptions{Group: "g"}, func(msg *mq.Message) error {
+		started <- string(msg.Data)
+		<-release
+		wg.Done()
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, provider.Publish(context.Background(), "fills", []byte("a1"), &mq.PublishOptions{OrderingKey: "a"}))
+	require.NoError(t, provider.Publish(context.Background(), "fills", []byte("b1"), &mq.PublishOptions{OrderingKey: "b"}))
+
+	got := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case body := <-started:
+			got[body] = true
+		case <-time.After(time.Second):
+			t.Fatal("different keys should start in parallel")
+		}
+	}
+	require.True(t, got["a1"] && got["b1"])
+	close(release)
+	wg.Wait()
+}
+
+func TestManagerRequireOrderedReliable(t *testing.T) {
+	mgr := mq.NewManager()
+	require.ErrorIs(t, mgr.RequireOrderedReliable(), mq.ErrOrderedReliableUnsupported)
+
+	basic := &basicProvider{}
+	mgr.Register(basic)
+	require.NoError(t, mgr.SetCurrent("basic"))
+	require.ErrorIs(t, mgr.RequireOrderedReliable(), mq.ErrOrderedReliableUnsupported)
+
+	mgr2 := mq.NewManager()
+	plain := mq.NewFakeOrderedReliableProvider()
+	mgr2.Register(plain)
+	require.NoError(t, mgr2.SetCurrent(plain.Name()))
+	require.NoError(t, mgr2.RequireOrderedReliable())
+}
+
+type basicProvider struct{}
+
+func (*basicProvider) Name() string                  { return "basic" }
+func (*basicProvider) Connect(context.Context) error { return nil }
+func (*basicProvider) Close() error                  { return nil }
+func (*basicProvider) Health(context.Context) error  { return nil }
+func (*basicProvider) Publish(context.Context, string, []byte, *mq.PublishOptions) error {
+	return nil
+}
+func (*basicProvider) Subscribe(context.Context, string, func(*mq.Message)) (func(), error) {
+	return func() {}, nil
+}

--- a/pkg/server/mq/provider_redis.go
+++ b/pkg/server/mq/provider_redis.go
@@ -65,6 +65,11 @@ func (r *RedisStreamProvider) Close() error {
 	return nil
 }
 
+// OrderedReliableInfo 声明 Redis Streams 在单 active owner 下的 ordered-reliable 能力。
+func (r *RedisStreamProvider) OrderedReliableInfo() OrderedReliableCapability {
+	return DefaultOrderedReliableCapability()
+}
+
 // Publish appends data to the Redis Stream identified by subject.
 func (r *RedisStreamProvider) Publish(ctx context.Context, subject string, data []byte, opts *PublishOptions) error {
 	if r.client == nil {
@@ -76,6 +81,9 @@ func (r *RedisStreamProvider) Publish(ctx context.Context, subject string, data 
 	}
 	if opts != nil && opts.IdempotencyKey != "" {
 		values["idempotency_key"] = opts.IdempotencyKey
+	}
+	if opts != nil && opts.OrderingKey != "" {
+		values["ordering_key"] = opts.OrderingKey
 	}
 	args := &redis.XAddArgs{
 		Stream: key,
@@ -171,8 +179,9 @@ func (r *RedisStreamProvider) SubscribeReliable(
 	if options.ClaimInterval < 50*time.Millisecond {
 		options.ClaimInterval = 50 * time.Millisecond
 	}
+	// ordered-reliable：单条处理，失败阻断同 stream 后续消息；多实例靠 owner lease 保证单 active。
 	if options.Count <= 0 {
-		options.Count = 10
+		options.Count = 1
 	}
 	key := r.streamKey(subject)
 	err := r.client.XGroupCreateMkStream(ctx, key, options.Group, "0").Err()
@@ -197,12 +206,52 @@ func (r *RedisStreamProvider) SubscribeReliable(
 	}, nil
 }
 
+func (r *RedisStreamProvider) ownerLockKey(subject, group string) string {
+	return r.prefix + ":ordered-owner:" + group + ":" + subject
+}
+
+func (r *RedisStreamProvider) tryAcquireOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
+	// TTL 略长于 claim 周期，持有者需周期性续约；崩溃后由其他实例接管。
+	ttl := options.MinIdle
+	if ttl < 2*time.Second {
+		ttl = 2 * time.Second
+	}
+	ok, err := r.client.SetNX(ctx, r.ownerLockKey(subject, options.Group), options.Consumer, ttl).Result()
+	return err == nil && ok
+}
+
+func (r *RedisStreamProvider) refreshOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
+	lockKey := r.ownerLockKey(subject, options.Group)
+	val, err := r.client.Get(ctx, lockKey).Result()
+	if err != nil {
+		return r.tryAcquireOwner(ctx, subject, options)
+	}
+	if val != options.Consumer {
+		return false
+	}
+	ttl := options.MinIdle
+	if ttl < 2*time.Second {
+		ttl = 2 * time.Second
+	}
+	_ = r.client.Expire(ctx, lockKey, ttl).Err()
+	return true
+}
+
+func (r *RedisStreamProvider) releaseOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) {
+	lockKey := r.ownerLockKey(subject, options.Group)
+	val, err := r.client.Get(ctx, lockKey).Result()
+	if err == nil && val == options.Consumer {
+		_ = r.client.Del(ctx, lockKey).Err()
+	}
+}
+
 func (r *RedisStreamProvider) runReliableSubscriber(
 	ctx context.Context,
 	key, subject string,
 	options ReliableSubscribeOptions,
 	handler func(*Message) error,
 ) {
+	defer r.releaseOwner(context.Background(), subject, options)
 	ticker := time.NewTicker(options.ClaimInterval)
 	defer ticker.Stop()
 	for {
@@ -210,12 +259,34 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			r.reclaimPending(ctx, key, subject, options, handler)
+			if r.refreshOwner(ctx, subject, options) {
+				// 仅 owner 认领超时 pending，避免多 active 并行越序。
+				if blocked := r.reclaimPending(ctx, key, subject, options, handler); blocked {
+					continue
+				}
+			}
 		default:
+		}
+		if !r.refreshOwner(ctx, subject, options) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+		// 先排空本 consumer 的 pending，失败则不读新消息（同 key / 同 stream 失败屏障）。
+		if blocked := r.processOwnPending(ctx, key, subject, options, handler); blocked {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
 		}
 		entries, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
 			Group: options.Group, Consumer: options.Consumer,
-			Streams: []string{key, ">"}, Count: options.Count, Block: 200 * time.Millisecond,
+			Streams: []string{key, ">"}, Count: 1, Block: 200 * time.Millisecond,
 		}).Result()
 		if err != nil {
 			if ctx.Err() != nil {
@@ -224,49 +295,82 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			continue
 		}
 		for _, stream := range entries {
-			r.handleReliableMessages(ctx, key, subject, options.Group, stream.Messages, handler)
+			_ = r.handleReliableMessages(ctx, key, subject, options.Group, stream.Messages, handler)
 		}
 	}
 }
 
+// processOwnPending 处理当前 consumer 的 PEL。返回 true 表示存在未成功消息，应阻断新消息。
+func (r *RedisStreamProvider) processOwnPending(
+	ctx context.Context,
+	key, subject string,
+	options ReliableSubscribeOptions,
+	handler func(*Message) error,
+) bool {
+	entries, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group: options.Group, Consumer: options.Consumer,
+		Streams: []string{key, "0"}, Count: 1, Block: 0,
+	}).Result()
+	if err != nil || len(entries) == 0 {
+		return false
+	}
+	for _, stream := range entries {
+		if len(stream.Messages) == 0 {
+			return false
+		}
+		if blocked := r.handleReliableMessages(ctx, key, subject, options.Group, stream.Messages, handler); blocked {
+			return true
+		}
+		// 还有 pending 时继续由上层循环拉取。
+		return true
+	}
+	return false
+}
+
+// reclaimPending 认领超时 pending。返回 true 表示处理失败应阻断。
 func (r *RedisStreamProvider) reclaimPending(
 	ctx context.Context,
 	key, subject string,
 	options ReliableSubscribeOptions,
 	handler func(*Message) error,
-) {
+) bool {
 	start := "0-0"
 	for {
 		messages, next, err := r.client.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 			Stream: key, Group: options.Group, Consumer: options.Consumer,
-			MinIdle: options.MinIdle, Start: start, Count: options.Count,
+			MinIdle: options.MinIdle, Start: start, Count: 1,
 		}).Result()
 		if err != nil || len(messages) == 0 {
-			return
+			return false
 		}
-		r.handleReliableMessages(ctx, key, subject, options.Group, messages, handler)
+		if blocked := r.handleReliableMessages(ctx, key, subject, options.Group, messages, handler); blocked {
+			return true
+		}
 		if next == "0-0" || next == start {
-			return
+			return false
 		}
 		start = next
 	}
 }
 
+// handleReliableMessages 按序处理；任一条失败则停止后续（失败屏障），返回 true。
 func (r *RedisStreamProvider) handleReliableMessages(
 	ctx context.Context,
 	key, subject, group string,
 	messages []redis.XMessage,
 	handler func(*Message) error,
-) {
+) bool {
 	for _, item := range messages {
 		data := redisMessageData(item.Values["data"])
 		messageID := item.ID
 		message := &Message{ID: messageID, Subject: subject, Data: data}
 		message.Ack = func() error { return r.client.XAck(ctx, key, group, messageID).Err() }
-		if err := handler(message); err == nil {
-			_ = message.Ack()
+		if err := handler(message); err != nil {
+			return true
 		}
+		_ = message.Ack()
 	}
+	return false
 }
 
 func redisMessageData(value interface{}) []byte {

--- a/pkg/server/mq/provider_redis.go
+++ b/pkg/server/mq/provider_redis.go
@@ -66,6 +66,8 @@ func (r *RedisStreamProvider) Close() error {
 }
 
 // OrderedReliableInfo 声明 Redis Streams 在单 active owner 下的 ordered-reliable 能力。
+// 当前实现以整条 stream 串行 + 失败阻断满足契约（比“仅同 key 阻断”更严）；
+// 不同 OrderingKey 的并行优化可后续用 shard stream 加强，不削弱本声明。
 func (r *RedisStreamProvider) OrderedReliableInfo() OrderedReliableCapability {
 	return DefaultOrderedReliableCapability()
 }
@@ -239,10 +241,14 @@ func (r *RedisStreamProvider) refreshOwner(ctx context.Context, subject string, 
 
 func (r *RedisStreamProvider) releaseOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) {
 	lockKey := r.ownerLockKey(subject, options.Group)
-	val, err := r.client.Get(ctx, lockKey).Result()
-	if err == nil && val == options.Consumer {
-		_ = r.client.Del(ctx, lockKey).Err()
-	}
+	// 仅删除仍由本 consumer 持有的锁，避免误删后继 owner。
+	script := redis.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`)
+	_ = script.Run(ctx, r.client, []string{lockKey}, options.Consumer).Err()
 }
 
 func (r *RedisStreamProvider) runReliableSubscriber(

--- a/pkg/server/router/servicecontext.go
+++ b/pkg/server/router/servicecontext.go
@@ -944,6 +944,15 @@ func (own *ServiceContext) UseOutbox(store event.OutboxStore) error {
 	})
 }
 
+// RequireOrderedReliableByShardKey 声明控制事件需要 ordered-reliable 能力。
+// 底层 provider 不支持或未装配外部 MQ 时 fail closed。
+func (own *ServiceContext) RequireOrderedReliableByShardKey() error {
+	if own == nil || own.ServiceEventBridge == nil {
+		return event.ErrServiceEventBridgeClosed
+	}
+	return own.ServiceEventBridge.RequireOrderedReliableByShardKey()
+}
+
 // NotifyOutbox 唤醒当前服务 Outbox 发布器尽快扫描本地 Outbox 表。
 func (own *ServiceContext) NotifyOutbox() {
 	if own == nil || own.ServiceEventBridge == nil {


### PR DESCRIPTION
## 背景

承接已合并的能力请求文档 `docs/codex/ORDERED_RELIABLE_MQ_CAPABILITY_REQUEST.md`，落地 provider-neutral 的 ordered-reliable 最小实现。

## 变更

- `PublishOptions.OrderingKey`；`MQBridge` 透传 `IdempotencyKey` + `ShardKey→OrderingKey`
- 可选 `OrderedReliableMQProvider` + `MQManager.RequireOrderedReliable`
- `ServiceEventBridge` / `ServiceContext.RequireOrderedReliableByShardKey` 启动 fail-closed
- 已声明 requirement 时空 `ShardKey` 发布失败（Ensure 成功后才开启门禁）
- Outbox 同 key failure barrier（本轮阻断，跨重启依赖 pending 恢复）
- Redis Streams：单 active owner lease（compare-and-del 释放）、pending 优先、失败阻断新消息、写入 `ordering_key`
- Fake provider + conformance 单测；Outbox barrier；Require fail-closed 单测

## 行为说明

- Redis `SubscribeReliable` 现为单 active owner + 整 stream 串行失败阻断（比“仅同 key 阻断”更严，契约兼容）
- 同 consumer group 多实例不再并行分片消费，standby 等 owner 释放/租约过期后接管
- NATS 仍未实现 ordered-reliable；声明 requirement 时若当前 provider 为 NATS 会 fail closed

## 非本 PR

- NATS JetStream `ReliableMQProvider` / ordered-reliable
- 按 OrderingKey 的 shard 并行优化
- 配置矩阵 / skill / release 文档同步

## 验证

```bash
go test ./pkg/server/mq/ ./pkg/server/event/ ./pkg/server/router/ -count=1
```