### PR TITLE
fix(mq): address ordered-reliable external audit nits

### DIFF
--- a/pkg/server/event/mqbridge.go
+++ b/pkg/server/event/mqbridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 
 	"github.com/digitalwayhk/core/pkg/server/mq"
 )
@@ -19,7 +20,7 @@ var ErrOrderingKeyRequired = errors.New("event: ordering key required")
 type MQBridge struct {
 	stream                 *Stream
 	manager                *mq.MQManager
-	requireOrderedReliable bool
+	requireOrderedReliable atomic.Bool
 }
 
 // NewMQBridge creates a bridge between the given Stream and MQManager.
@@ -35,13 +36,13 @@ func (b *MQBridge) EnsureOrderedReliable() error {
 	if err := b.manager.RequireOrderedReliable(); err != nil {
 		return err
 	}
-	b.requireOrderedReliable = true
+	b.requireOrderedReliable.Store(true)
 	return nil
 }
 
 // RequiresOrderedReliable 报告是否已开启 ordered-reliable 发布门禁。
 func (b *MQBridge) RequiresOrderedReliable() bool {
-	return b != nil && b.requireOrderedReliable
+	return b != nil && b.requireOrderedReliable.Load()
 }
 
 // Publish serialises env to JSON and delivers it to the MQ provider on subject.
@@ -50,7 +51,7 @@ func (b *MQBridge) Publish(ctx context.Context, subject string, env *Envelope) e
 	if env == nil {
 		return ErrInvalidPublishRequest
 	}
-	if b.requireOrderedReliable && env.ShardKey == "" {
+	if b.requireOrderedReliable.Load() && env.ShardKey == "" {
 		return ErrOrderingKeyRequired
 	}
 	data, err := json.Marshal(env)

--- a/pkg/server/event/ordered_reliable_require_test.go
+++ b/pkg/server/event/ordered_reliable_require_test.go
@@ -79,3 +79,23 @@ func TestRequireOrderedReliableOptionDefersUntilExternalEnsured(t *testing.T) {
 	bridge.SetExternalPublisher(event.NewMQBridge(stream, mgr))
 	require.True(t, bridge.RequiresOrderedReliable())
 }
+
+func TestRequireOrderedReliableOptionWithIncapableProviderFailClosedOnPublish(t *testing.T) {
+	// option=true + 无能力 provider 不得静默降级为无序伪 key 路径。
+	bridge := event.NewServiceEventBridge(event.NewStream(), event.ServiceEventBridgeOptions{
+		SubscriberID:                     "svc",
+		RequireOrderedReliableByShardKey: true,
+	})
+	bridge.SetExternalPublisher(&plainExternal{})
+	require.False(t, bridge.RequiresOrderedReliable())
+
+	env := event.NewEnvelope("svc", "fill", []byte(`{}`))
+	env.ShardKey = "market-a"
+	err := bridge.Publish(context.Background(), event.PublishRequest{
+		Class:    event.ControlDelivery,
+		External: true,
+		Subject:  "fills",
+		Envelope: env,
+	})
+	require.ErrorIs(t, err, event.ErrOrderedReliableUnsupported)
+}

--- a/pkg/server/event/outbox.go
+++ b/pkg/server/event/outbox.go
@@ -24,9 +24,18 @@ type OutboxMessage struct {
 
 // OutboxStore 只负责访问本服务本地 Outbox 表。
 // 可靠性来自业务事实与 Outbox 在同一数据库事务内提交。
+//
+// LoadPending 必须按持久化 earliest-first 顺序返回 unpublished 记录
+// （通常按主键/创建时间升序）。跨重启的同 key 屏障依赖该顺序；乱序返回会导致越序发布。
 type OutboxStore interface {
 	LoadPending(ctx context.Context, limit int) ([]OutboxMessage, error)
 	MarkPublished(ctx context.Context, message OutboxMessage) error
+}
+
+// OutboxStoreSkipBlocked 是可选扩展：LoadPending 时跳过指定 OrderingKey（ShardKey），
+// 避免单 hot key 卡死占满 batch 后饿死其他 key。实现方应对 skip 后的结果仍保持 earliest-first。
+type OutboxStoreSkipBlocked interface {
+	LoadPendingSkipping(ctx context.Context, limit int, skipOrderingKeys []string) ([]OutboxMessage, error)
 }
 
 type OutboxOptions struct {
@@ -94,10 +103,12 @@ func (p *outboxPublisher) run(ctx context.Context) {
 
 func (p *outboxPublisher) drain(ctx context.Context) {
 	// 本轮同 OrderingKey 失败屏障：最早失败的 key 阻断后续同 key 记录，其他 key 可继续。
-	// 屏障仅用于本轮 drain；跨重启依赖 LoadPending 仍返回 earliest unpublished。
+	// 跨重启依赖 LoadPending 仍按 earliest-first 返回 unpublished。
+	// 若 store 实现 OutboxStoreSkipBlocked，可跳过已 blocked 的 key，避免 hot key 饿死其他 key。
 	blocked := make(map[string]struct{})
+	noProgressRounds := 0
 	for {
-		items, err := p.store.LoadPending(ctx, p.batch)
+		items, err := p.loadPending(ctx, blocked)
 		if err != nil {
 			logx.Errorw("event_outbox_load_failed", logx.Field("service", p.source), logx.Field("error", err))
 			return
@@ -124,10 +135,36 @@ func (p *outboxPublisher) drain(ctx context.Context) {
 			}
 			progressed = true
 		}
-		if len(items) < p.batch || !progressed {
+		if progressed {
+			noProgressRounds = 0
+			if len(items) < p.batch {
+				return
+			}
+			continue
+		}
+		// 本批无进展：若 store 支持 skip blocked key，再拉一轮，避免 hot key 饿死其他 key。
+		noProgressRounds++
+		if noProgressRounds >= 2 {
 			return
 		}
+		if _, ok := p.store.(OutboxStoreSkipBlocked); ok && len(blocked) > 0 {
+			continue
+		}
+		return
 	}
+}
+
+func (p *outboxPublisher) loadPending(ctx context.Context, blocked map[string]struct{}) ([]OutboxMessage, error) {
+	if len(blocked) > 0 {
+		if skipper, ok := p.store.(OutboxStoreSkipBlocked); ok {
+			keys := make([]string, 0, len(blocked))
+			for k := range blocked {
+				keys = append(keys, k)
+			}
+			return skipper.LoadPendingSkipping(ctx, p.batch, keys)
+		}
+	}
+	return p.store.LoadPending(ctx, p.batch)
 }
 
 func outboxOrderingKey(item OutboxMessage) string {

--- a/pkg/server/event/outbox_barrier_test.go
+++ b/pkg/server/event/outbox_barrier_test.go
@@ -28,6 +28,31 @@ func (s *barrierStore) LoadPending(_ context.Context, limit int) ([]event.Outbox
 	return out, nil
 }
 
+// LoadPendingSkipping 跳过 blocked ordering keys，保证其他 key 仍可推进。
+func (s *barrierStore) LoadPendingSkipping(_ context.Context, limit int, skipOrderingKeys []string) ([]event.OutboxMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	skip := make(map[string]struct{}, len(skipOrderingKeys))
+	for _, k := range skipOrderingKeys {
+		skip[k] = struct{}{}
+	}
+	out := make([]event.OutboxMessage, 0, limit)
+	for _, item := range s.pending {
+		key := item.ShardKey
+		if key == "" {
+			key = item.EventType + ":" + item.EventID
+		}
+		if _, blocked := skip[key]; blocked {
+			continue
+		}
+		out = append(out, item)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 func (s *barrierStore) MarkPublished(_ context.Context, message event.OutboxMessage) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -88,4 +113,74 @@ func TestOutboxSameKeyFailureBarrierAllowsOtherKeys(t *testing.T) {
 	marked := append([]string(nil), store.marked...)
 	store.mu.Unlock()
 	require.Equal(t, []string{"a1", "b1"}, marked)
+}
+
+func TestOutboxHotKeyDoesNotStarveOtherKeysWithSkipStore(t *testing.T) {
+	stream := event.NewStream()
+	bridge := event.NewServiceEventBridge(stream, event.ServiceEventBridgeOptions{SubscriberID: "svc"})
+	external := &barrierExternal{failID: "a1"}
+	bridge.SetExternalPublisher(external)
+	// batchSize=2：hot key a 的两条占满首批；无 Skip 时 b1 永远进不了批。
+	store := &barrierStore{pending: []event.OutboxMessage{
+		{EventID: "a1", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a1")},
+		{EventID: "a2", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a2")},
+		{EventID: "b1", EventType: "fill", Subject: "fills", ShardKey: "market-b", Payload: []byte("b1")},
+	}}
+	require.NoError(t, bridge.UseOutbox(event.OutboxOptions{
+		SourceService: "trades",
+		Store:         store,
+		Interval:      time.Hour,
+		BatchSize:     2,
+		External:      true,
+	}))
+	bridge.NotifyOutbox()
+	time.Sleep(150 * time.Millisecond)
+
+	external.mu.Lock()
+	published := append([]string(nil), external.published...)
+	external.mu.Unlock()
+	require.Equal(t, []string{"b1"}, published)
+}
+
+func TestOutboxBarrierSurvivesPublisherRestart(t *testing.T) {
+	stream := event.NewStream()
+	external := &barrierExternal{failID: "a2"}
+	store := &barrierStore{pending: []event.OutboxMessage{
+		{EventID: "a1", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a1")},
+		{EventID: "a2", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a2")},
+		{EventID: "a3", EventType: "fill", Subject: "fills", ShardKey: "market-a", Payload: []byte("a3")},
+		{EventID: "b1", EventType: "fill", Subject: "fills", ShardKey: "market-b", Payload: []byte("b1")},
+	}}
+
+	bridge1 := event.NewServiceEventBridge(stream, event.ServiceEventBridgeOptions{SubscriberID: "svc"})
+	bridge1.SetExternalPublisher(external)
+	require.NoError(t, bridge1.UseOutbox(event.OutboxOptions{
+		SourceService: "trades", Store: store, Interval: time.Hour, BatchSize: 10, External: true,
+	}))
+	bridge1.NotifyOutbox()
+	time.Sleep(150 * time.Millisecond)
+	require.NoError(t, bridge1.Close(context.Background()))
+
+	// 新 publisher 实例：a2 仍失败，a3 不得越过；b1 可继续。
+	bridge2 := event.NewServiceEventBridge(stream, event.ServiceEventBridgeOptions{SubscriberID: "svc"})
+	bridge2.SetExternalPublisher(external)
+	require.NoError(t, bridge2.UseOutbox(event.OutboxOptions{
+		SourceService: "trades", Store: store, Interval: time.Hour, BatchSize: 10, External: true,
+	}))
+	bridge2.NotifyOutbox()
+	time.Sleep(150 * time.Millisecond)
+
+	external.mu.Lock()
+	published := append([]string(nil), external.published...)
+	external.mu.Unlock()
+	require.Equal(t, []string{"a1", "b1"}, published)
+	// a3 仍 unpublished
+	store.mu.Lock()
+	var remaining []string
+	for _, item := range store.pending {
+		remaining = append(remaining, item.EventID)
+	}
+	store.mu.Unlock()
+	require.Contains(t, remaining, "a2")
+	require.Contains(t, remaining, "a3")
 }

--- a/pkg/server/event/servicebridge.go
+++ b/pkg/server/event/servicebridge.go
@@ -93,13 +93,18 @@ type ServiceEventBridge struct {
 	outboxMu              sync.Mutex
 	outbox                *outboxPublisher
 	subscriberID          string
-	// wantOrderedReliable 来自构造选项，表示意图；真正开启门禁必须 Ensure 成功。
+	// wantOrderedReliable 来自构造选项或显式 Require，表示意图；真正开启门禁必须 Ensure 成功。
 	wantOrderedReliable bool
 	// requireOrderedReliable 仅在 EnsureOrderedReliable 成功后置位。
 	requireOrderedReliable atomic.Bool
-	dropped                atomic.Uint64
-	controlQueueTimeouts   atomic.Uint64
+	// orderedReliableEnsureErr 记录最近一次 Ensure 失败，避免 option 路径静默降级。
+	// 存 *errorBox；nil box 表示尚无失败记录。
+	orderedReliableEnsureErr atomic.Value
+	dropped                  atomic.Uint64
+	controlQueueTimeouts     atomic.Uint64
 }
+
+type errorBox struct{ err error }
 
 func NewServiceEventBridge(stream *Stream, options ServiceEventBridgeOptions) *ServiceEventBridge {
 	if stream == nil {
@@ -155,7 +160,7 @@ func (b *ServiceEventBridge) SetExternalPublisher(publisher ExternalPublisher) {
 	b.reliableSubscriber, _ = publisher.(ReliableExternalSubscriber)
 	want := b.wantOrderedReliable
 	b.externalMu.Unlock()
-	// 构造时声明了 requirement：装配外部适配器后立即 Ensure，失败则保持未开启（后续 Publish/Require 仍 fail closed）。
+	// 构造时声明了 requirement：装配后立即 Ensure；失败暂存错误，外发路径 fail closed（禁止静默降级）。
 	if want && publisher != nil {
 		_ = b.ensureOrderedReliableOn(publisher)
 	}
@@ -172,22 +177,44 @@ func (b *ServiceEventBridge) RequireOrderedReliableByShardKey() error {
 	publisher := b.external
 	b.externalMu.Unlock()
 	if publisher == nil {
-		return ErrExternalProviderUnavailable
+		err := ErrExternalProviderUnavailable
+		b.storeOrderedReliableEnsureErr(err)
+		return err
 	}
 	return b.ensureOrderedReliableOn(publisher)
+}
+
+func (b *ServiceEventBridge) storeOrderedReliableEnsureErr(err error) {
+	b.orderedReliableEnsureErr.Store(errorBox{err: err})
+}
+
+func (b *ServiceEventBridge) loadOrderedReliableEnsureErr() error {
+	v := b.orderedReliableEnsureErr.Load()
+	if v == nil {
+		return nil
+	}
+	box, ok := v.(errorBox)
+	if !ok {
+		return nil
+	}
+	return box.err
 }
 
 func (b *ServiceEventBridge) ensureOrderedReliableOn(publisher ExternalPublisher) error {
 	ensurer, ok := publisher.(orderedReliableEnsurer)
 	if !ok {
 		b.requireOrderedReliable.Store(false)
-		return ErrOrderedReliableUnsupported
+		err := ErrOrderedReliableUnsupported
+		b.storeOrderedReliableEnsureErr(err)
+		return err
 	}
 	if err := ensurer.EnsureOrderedReliable(); err != nil {
 		b.requireOrderedReliable.Store(false)
+		b.storeOrderedReliableEnsureErr(err)
 		return err
 	}
 	b.requireOrderedReliable.Store(true)
+	b.storeOrderedReliableEnsureErr(nil)
 	return nil
 }
 
@@ -206,6 +233,26 @@ func (b *ServiceEventBridge) RequiresOrderedReliable() bool {
 		return ensurer.RequiresOrderedReliable()
 	}
 	return false
+}
+
+// orderedReliableRequiredButUnavailable 为 true 时：已声明 requirement 但 Ensure 未成功，外发必须 fail closed。
+func (b *ServiceEventBridge) orderedReliableRequiredButUnavailable() error {
+	if b == nil {
+		return nil
+	}
+	if b.requireOrderedReliable.Load() {
+		return nil
+	}
+	b.externalMu.RLock()
+	want := b.wantOrderedReliable
+	b.externalMu.RUnlock()
+	if !want {
+		return nil
+	}
+	if err := b.loadOrderedReliableEnsureErr(); err != nil {
+		return err
+	}
+	return ErrOrderedReliableUnsupported
 }
 
 func (b *ServiceEventBridge) HasExternalPublisher() bool {
@@ -341,6 +388,12 @@ func (b *ServiceEventBridge) Publish(ctx context.Context, request PublishRequest
 	}
 	if request.External && b.externalPublisher() == nil {
 		return ErrExternalProviderUnavailable
+	}
+	// 已声明 requirement 但 Ensure 失败：禁止静默降级为无序/伪 key。
+	if request.External {
+		if err := b.orderedReliableRequiredButUnavailable(); err != nil {
+			return err
+		}
 	}
 	if request.External && b.RequiresOrderedReliable() && request.Envelope.ShardKey == "" {
 		return ErrOrderingKeyRequired

--- a/pkg/server/mq/ordered_reliable_conformance.go
+++ b/pkg/server/mq/ordered_reliable_conformance.go
@@ -1,0 +1,92 @@
+package mq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// VerifyOrderedReliableFailureBarrier 运行最小 conformance：同 key 失败时后续不得越过。
+// 用于拒绝「Info 合法但不阻断」的撒谎 provider（§7.10）。
+func VerifyOrderedReliableFailureBarrier(provider OrderedReliableMQProvider) error {
+	if provider == nil {
+		return ErrOrderedReliableUnsupported
+	}
+	if !provider.OrderedReliableInfo().Valid() {
+		return ErrOrderedReliableUnsupported
+	}
+	base, ok := provider.(MQProvider)
+	if !ok {
+		return fmt.Errorf("mq conformance: provider must implement MQProvider")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		got     []string
+		allowM3 atomic.Bool
+		m3Fail  atomic.Int32
+	)
+	subCancel, err := provider.SubscribeReliable(ctx, "conformance.fills", ReliableSubscribeOptions{
+		Group: "conformance", MinIdle: 100 * time.Millisecond, ClaimInterval: 50 * time.Millisecond,
+	}, func(msg *Message) error {
+		body := string(msg.Data)
+		if body == "m3" && !allowM3.Load() {
+			m3Fail.Add(1)
+			return errors.New("conformance barrier")
+		}
+		mu.Lock()
+		got = append(got, body)
+		mu.Unlock()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	defer subCancel()
+
+	for _, body := range []string{"m1", "m2", "m3", "m4"} {
+		if err := base.Publish(ctx, "conformance.fills", []byte(body), &PublishOptions{
+			OrderingKey: "k", IdempotencyKey: body,
+		}); err != nil {
+			return err
+		}
+	}
+	// 等待至少一次 m3 失败与 m1/m2 完成
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if m3Fail.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if m3Fail.Load() < 1 {
+		return fmt.Errorf("mq conformance: expected handler failure on m3")
+	}
+	time.Sleep(80 * time.Millisecond)
+	mu.Lock()
+	snapshot := append([]string(nil), got...)
+	mu.Unlock()
+	for _, body := range snapshot {
+		if body == "m4" {
+			return fmt.Errorf("mq conformance: m4 executed while m3 blocked (lying/no barrier)")
+		}
+	}
+	for _, want := range []string{"m1", "m2"} {
+		found := false
+		for _, body := range snapshot {
+			if body == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("mq conformance: missing %s before barrier, got %v", want, snapshot)
+		}
+	}
+	return nil
+}

--- a/pkg/server/mq/ordered_reliable_test.go
+++ b/pkg/server/mq/ordered_reliable_test.go
@@ -3,6 +3,7 @@ package mq_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -112,6 +113,111 @@ func TestManagerRequireOrderedReliable(t *testing.T) {
 	mgr2.Register(plain)
 	require.NoError(t, mgr2.SetCurrent(plain.Name()))
 	require.NoError(t, mgr2.RequireOrderedReliable())
+}
+
+func TestFakeOrderedReliableOneHundredStrictOrder(t *testing.T) {
+	provider := mq.NewFakeOrderedReliableProvider()
+	const n = 100
+	got := make([]int, 0, n)
+	done := make(chan struct{})
+	_, err := provider.SubscribeReliable(context.Background(), "fills", mq.ReliableSubscribeOptions{Group: "g"}, func(msg *mq.Message) error {
+		var v int
+		_, _ = fmt.Sscanf(string(msg.Data), "%d", &v)
+		got = append(got, v)
+		if len(got) == n {
+			close(done)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	for i := 1; i <= n; i++ {
+		body := fmt.Sprintf("%d", i)
+		require.NoError(t, provider.Publish(context.Background(), "fills", []byte(body), &mq.PublishOptions{
+			OrderingKey: "k", IdempotencyKey: body,
+		}))
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout got=%d", len(got))
+	}
+	for i := 0; i < n; i++ {
+		require.Equal(t, i+1, got[i])
+	}
+}
+
+func TestFakeOrderedReliableRedeliveryKeepsIdentity(t *testing.T) {
+	provider := mq.NewFakeOrderedReliableProvider()
+	var (
+		attempts atomic.Int32
+		seen     *mq.Message
+		done     = make(chan struct{})
+	)
+	_, err := provider.SubscribeReliable(context.Background(), "fills", mq.ReliableSubscribeOptions{Group: "g"}, func(msg *mq.Message) error {
+		if attempts.Add(1) == 1 {
+			seen = &mq.Message{ID: msg.ID, Subject: msg.Subject, Data: append([]byte(nil), msg.Data...)}
+			return errors.New("retry")
+		}
+		require.Equal(t, seen.ID, msg.ID)
+		require.Equal(t, seen.Subject, msg.Subject)
+		require.Equal(t, seen.Data, msg.Data)
+		close(done)
+		return nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, provider.Publish(context.Background(), "fills", []byte(`{"x":1}`), &mq.PublishOptions{
+		OrderingKey: "market-a", IdempotencyKey: "evt-1",
+	}))
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+	require.Equal(t, "evt-1", seen.ID)
+}
+
+// lyingOrderedProvider 自报合法 capability，但不做失败阻断（同 key 可越序推进）。
+type lyingOrderedProvider struct {
+	mu   sync.Mutex
+	subs []func(*mq.Message) error
+}
+
+func (*lyingOrderedProvider) Name() string                  { return "lying-ordered" }
+func (*lyingOrderedProvider) Connect(context.Context) error { return nil }
+func (*lyingOrderedProvider) Close() error                  { return nil }
+func (*lyingOrderedProvider) Health(context.Context) error  { return nil }
+func (*lyingOrderedProvider) OrderedReliableInfo() mq.OrderedReliableCapability {
+	return mq.DefaultOrderedReliableCapability()
+}
+func (*lyingOrderedProvider) Subscribe(context.Context, string, func(*mq.Message)) (func(), error) {
+	return func() {}, nil
+}
+func (p *lyingOrderedProvider) Publish(_ context.Context, subject string, data []byte, _ *mq.PublishOptions) error {
+	p.mu.Lock()
+	handlers := append([]func(*mq.Message) error(nil), p.subs...)
+	p.mu.Unlock()
+	msg := &mq.Message{ID: string(data), Subject: subject, Data: data, Ack: func() error { return nil }}
+	for _, h := range handlers {
+		_ = h(msg) // 故意忽略错误并继续——违反失败阻断
+	}
+	return nil
+}
+func (p *lyingOrderedProvider) SubscribeReliable(_ context.Context, _ string, _ mq.ReliableSubscribeOptions, handler func(*mq.Message) error) (func(), error) {
+	p.mu.Lock()
+	p.subs = append(p.subs, handler)
+	p.mu.Unlock()
+	return func() {}, nil
+}
+
+func TestConformanceRejectsLyingOrderedProvider(t *testing.T) {
+	// §7.10：capability 自报合法但实际不阻断 → conformance 必须拒绝。
+	lying := &lyingOrderedProvider{}
+	mgr := mq.NewManager()
+	mgr.Register(lying)
+	require.NoError(t, mgr.SetCurrent(lying.Name()))
+	// 启动门禁仅看 Info，撒谎者可通过（已知限制）；conformance 行为套件必须抓出。
+	require.NoError(t, mgr.RequireOrderedReliable())
+	require.Error(t, mq.VerifyOrderedReliableFailureBarrier(lying))
 }
 
 type basicProvider struct{}

--- a/pkg/server/mq/provider_redis.go
+++ b/pkg/server/mq/provider_redis.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/zeromicro/go-zero/core/logx"
 )
 
 // RedisStreamProvider implements MQProvider using Redis Streams.
@@ -181,10 +182,9 @@ func (r *RedisStreamProvider) SubscribeReliable(
 	if options.ClaimInterval < 50*time.Millisecond {
 		options.ClaimInterval = 50 * time.Millisecond
 	}
-	// ordered-reliable：单条处理，失败阻断同 stream 后续消息；多实例靠 owner lease 保证单 active。
-	if options.Count <= 0 {
-		options.Count = 1
-	}
+	// ordered-reliable：强制单条处理，失败阻断后续；多实例靠 owner lease 保证单 active。
+	// 显式 Count>1 会被忽略，避免同批入 PEL 后语义与注释不一致。
+	options.Count = 1
 	key := r.streamKey(subject)
 	err := r.client.XGroupCreateMkStream(ctx, key, options.Group, "0").Err()
 	if err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
@@ -212,43 +212,63 @@ func (r *RedisStreamProvider) ownerLockKey(subject, group string) string {
 	return r.prefix + ":ordered-owner:" + group + ":" + subject
 }
 
-func (r *RedisStreamProvider) tryAcquireOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
-	// TTL 略长于 claim 周期，持有者需周期性续约；崩溃后由其他实例接管。
-	ttl := options.MinIdle
-	if ttl < 2*time.Second {
-		ttl = 2 * time.Second
+// ownerLeaseTTL 与 MinIdle 解耦：lease 必须覆盖单条 handler 执行时间，
+// 避免 handler 慢于 MinIdle 时旧 owner 仍在处理、新 owner 已开始读新消息导致越序。
+// XAutoClaim 仍用 MinIdle 认领崩溃实例的 pending；lease 更长，正常慢 handler 不会丢 owner。
+func ownerLeaseTTL(options ReliableSubscribeOptions) time.Duration {
+	ttl := 3 * options.MinIdle
+	if ttl < 2*time.Minute {
+		ttl = 2 * time.Minute
 	}
-	ok, err := r.client.SetNX(ctx, r.ownerLockKey(subject, options.Group), options.Consumer, ttl).Result()
-	return err == nil && ok
+	if options.MinIdle > 0 && ttl < options.MinIdle+30*time.Second {
+		ttl = options.MinIdle + 30*time.Second
+	}
+	return ttl
 }
 
-func (r *RedisStreamProvider) refreshOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
-	lockKey := r.ownerLockKey(subject, options.Group)
-	val, err := r.client.Get(ctx, lockKey).Result()
-	if err != nil {
-		return r.tryAcquireOwner(ctx, subject, options)
-	}
-	if val != options.Consumer {
-		return false
-	}
-	ttl := options.MinIdle
-	if ttl < 2*time.Second {
-		ttl = 2 * time.Second
-	}
-	_ = r.client.Expire(ctx, lockKey, ttl).Err()
-	return true
-}
+var redisOwnerRefreshScript = redis.NewScript(`
+local cur = redis.call("GET", KEYS[1])
+if not cur then
+  return redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2]) and 1 or 0
+end
+if cur == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+end
+return 0
+`)
 
-func (r *RedisStreamProvider) releaseOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) {
-	lockKey := r.ownerLockKey(subject, options.Group)
-	// 仅删除仍由本 consumer 持有的锁，避免误删后继 owner。
-	script := redis.NewScript(`
+var redisOwnerReleaseScript = redis.NewScript(`
 if redis.call("GET", KEYS[1]) == ARGV[1] then
   return redis.call("DEL", KEYS[1])
 end
 return 0
 `)
-	_ = script.Run(ctx, r.client, []string{lockKey}, options.Consumer).Err()
+
+func (r *RedisStreamProvider) tryAcquireOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
+	ttl := ownerLeaseTTL(options)
+	ok, err := r.client.SetNX(ctx, r.ownerLockKey(subject, options.Group), options.Consumer, ttl).Result()
+	return err == nil && ok
+}
+
+// refreshOwner 原子续约：仅当仍为本 consumer 时 PEXPIRE；锁不存在则尝试抢占。
+func (r *RedisStreamProvider) refreshOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
+	lockKey := r.ownerLockKey(subject, options.Group)
+	ttlMs := ownerLeaseTTL(options).Milliseconds()
+	n, err := redisOwnerRefreshScript.Run(ctx, r.client, []string{lockKey}, options.Consumer, ttlMs).Int()
+	if err != nil {
+		return false
+	}
+	return n == 1
+}
+
+func (r *RedisStreamProvider) releaseOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) {
+	lockKey := r.ownerLockKey(subject, options.Group)
+	_ = redisOwnerReleaseScript.Run(ctx, r.client, []string{lockKey}, options.Consumer).Err()
+}
+
+// stillOwner 在 handler 完成后做 fencing 检查：已丢 owner 则不得 ACK。
+func (r *RedisStreamProvider) stillOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
+	return r.refreshOwner(ctx, subject, options)
 }
 
 func (r *RedisStreamProvider) runReliableSubscriber(
@@ -283,11 +303,19 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 		}
 		// 先排空本 consumer 的 pending，失败则不读新消息（同 key / 同 stream 失败屏障）。
 		if blocked := r.processOwnPending(ctx, key, subject, options, handler); blocked {
+			// 仅失败时 backoff；成功排空 pending 不睡，避免 N×50ms 延迟税。
+			if !r.stillOwner(ctx, subject, options) {
+				continue
+			}
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(50 * time.Millisecond):
 			}
+			continue
+		}
+		// 读新消息前再次确认 owner，缩小双 active 窗口。
+		if !r.stillOwner(ctx, subject, options) {
 			continue
 		}
 		entries, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
@@ -301,7 +329,7 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			continue
 		}
 		for _, stream := range entries {
-			_ = r.handleReliableMessages(ctx, key, subject, options.Group, stream.Messages, handler)
+			_ = r.handleReliableMessages(ctx, key, subject, options, stream.Messages, handler)
 		}
 	}
 }
@@ -313,24 +341,29 @@ func (r *RedisStreamProvider) processOwnPending(
 	options ReliableSubscribeOptions,
 	handler func(*Message) error,
 ) bool {
-	entries, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
-		Group: options.Group, Consumer: options.Consumer,
-		Streams: []string{key, "0"}, Count: 1, Block: 0,
-	}).Result()
-	if err != nil || len(entries) == 0 {
-		return false
-	}
-	for _, stream := range entries {
-		if len(stream.Messages) == 0 {
+	// 连续排空 pending，成功路径不人为 sleep。
+	for {
+		entries, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group: options.Group, Consumer: options.Consumer,
+			Streams: []string{key, "0"}, Count: 1, Block: 0,
+		}).Result()
+		if err != nil || len(entries) == 0 {
 			return false
 		}
-		if blocked := r.handleReliableMessages(ctx, key, subject, options.Group, stream.Messages, handler); blocked {
-			return true
+		has := false
+		for _, stream := range entries {
+			if len(stream.Messages) == 0 {
+				continue
+			}
+			has = true
+			if blocked := r.handleReliableMessages(ctx, key, subject, options, stream.Messages, handler); blocked {
+				return true
+			}
 		}
-		// 还有 pending 时继续由上层循环拉取。
-		return true
+		if !has {
+			return false
+		}
 	}
-	return false
 }
 
 // reclaimPending 认领超时 pending。返回 true 表示处理失败应阻断。
@@ -349,7 +382,7 @@ func (r *RedisStreamProvider) reclaimPending(
 		if err != nil || len(messages) == 0 {
 			return false
 		}
-		if blocked := r.handleReliableMessages(ctx, key, subject, options.Group, messages, handler); blocked {
+		if blocked := r.handleReliableMessages(ctx, key, subject, options, messages, handler); blocked {
 			return true
 		}
 		if next == "0-0" || next == start {
@@ -360,18 +393,39 @@ func (r *RedisStreamProvider) reclaimPending(
 }
 
 // handleReliableMessages 按序处理；任一条失败则停止后续（失败屏障），返回 true。
+// handler 成功后若已丢 owner（lease fencing），不 ACK，留给新 owner 重投，避免双写/越序。
 func (r *RedisStreamProvider) handleReliableMessages(
 	ctx context.Context,
-	key, subject, group string,
+	key, subject string,
+	options ReliableSubscribeOptions,
 	messages []redis.XMessage,
 	handler func(*Message) error,
 ) bool {
+	group := options.Group
 	for _, item := range messages {
 		data := redisMessageData(item.Values["data"])
 		messageID := item.ID
+		orderingKey := redisMessageData(item.Values["ordering_key"])
+		idem := redisMessageData(item.Values["idempotency_key"])
 		message := &Message{ID: messageID, Subject: subject, Data: data}
 		message.Ack = func() error { return r.client.XAck(ctx, key, group, messageID).Err() }
 		if err := handler(message); err != nil {
+			logx.Errorw("mq_redis_reliable_handler_failed",
+				logx.Field("subject", subject),
+				logx.Field("message_id", messageID),
+				logx.Field("ordering_key", string(orderingKey)),
+				logx.Field("idempotency_key", string(idem)),
+				logx.Field("error", err),
+			)
+			return true
+		}
+		// fencing：handler 期间若 lease 过期被接管，禁止 ACK。
+		if !r.stillOwner(ctx, subject, options) {
+			logx.Errorw("mq_redis_reliable_lost_owner_skip_ack",
+				logx.Field("subject", subject),
+				logx.Field("message_id", messageID),
+				logx.Field("ordering_key", string(orderingKey)),
+			)
 			return true
 		}
 		_ = message.Ack()


### PR DESCRIPTION
## 背景

外部审计对已合并的 ordered-reliable 实现给出 `APPROVE_WITH_NITS`，本 PR 收口发版前应修项。

## 修复对照

| 审计项 | 处理 |
|---|---|
| P1 owner lease 无 fencing | lease TTL 与 MinIdle 解耦（≥2min / 3×MinIdle）；Lua 原子续约；handler 后 lost-owner 不 ACK |
| P2 option 静默降级 | want 声明后 Ensure 失败暂存错误；外发 Publish fail-closed |
| P2 §7.10 撒谎 provider | `VerifyOrderedReliableFailureBarrier` + lying provider 测试 |
| P2 Outbox hot-key 饿死 | 可选 `OutboxStoreSkipBlocked` + drain 再拉一轮 |
| P2 跨重启 / store 顺序 | 接口注释 earliest-first + 重启 barrier 测试 |
| P2 消费失败无日志 | Redis handler 失败打 message_id/ordering_key |
| P2 MQBridge race | `atomic.Bool` |
| P3 Count>1 | reliable 强制 Count=1 |
| P3 pending 50ms 税 | 成功排空 pending 不 sleep |

## 验证

```bash
go test ./pkg/server/mq/ ./pkg/server/event/ ./pkg/server/router/ -count=1
```