### PR TITLE
fix(mq): ordered-reliable residual (reclaim-before-new + docs)

### DIFF
--- a/docs/codex/API_COMPATIBILITY_SURFACE.md
+++ b/docs/codex/API_COMPATIBILITY_SURFACE.md
@@ -18,6 +18,9 @@
 | `pkg/server/types.IRouter`、`IRequest`、`IResponse`、`RouterInfo` | Stable | server/router | public/private/manage 路由、服务间调用 | `pkg/server/types/router.go`、`interface.go`、examples |
 | `pkg/server/config.ServerConfig` 及项目自有子配置 | Stable（按能力矩阵） | server/config | 服务配置、默认化和启动校验 | 任务 14 配置矩阵与 `config-contract` |
 | `pkg/server/event` 的 EventBus、EventStream 与 Bridge 入口 | Stable（按能力矩阵） | server/event | 进程内事件与受支持 MQ 事件流 | event 单元测试与任务 14 生命周期测试 |
+| `mq.PublishOptions.OrderingKey`、`OrderedReliableMQProvider`、`MQManager.RequireOrderedReliable` | Stable（加性） | server/mq | 按 key 有序可靠投递的可选契约；未声明 requirement 时零值兼容 | `pkg/server/mq` unit/conformance；Redis 需 `CORE_TEST_REDIS_ADDR` |
+| `event.MQBridge` 透传 IdempotencyKey/OrderingKey、`EnsureOrderedReliable` | Stable（加性） | server/event | Envelope → provider 元数据；Require 后门禁空 ShardKey | mqbridge 与 ordered-reliable require 测试 |
+| `ServiceEventBridge`/`ServiceContext.RequireOrderedReliableByShardKey`、`OutboxStore` earliest-first 与可选 `OutboxStoreSkipBlocked` | Stable（加性） | server/event、router | 启动 fail-closed、Outbox 同 key barrier、hot-key 可选跳过 | outbox barrier / require 测试 |
 | `pkg/server/router.DefaultRouterInfo`、`NewRouterInfo` | Stable | server/router | 普通服务路由元数据 | `pkg/server/router/servicerouter.go`、`use-digitalway-core` skill |
 | `router.WithInternalCallers`、`RouterInfo.GetInternalCallers`、可信调用方上下文读取契约 | Stable security | server/router | 受限内部 Public 的冻结白名单与执行前授权 | RouterInfo 冻结、同进程、gRPC mTLS 身份和示例 06 测试 |
 | `pkg/server/router.NewServiceContext`、`NewServiceContextWithConfig` | Stable | server/router | 文件配置启动、程序化启动 | 任务 14 生产构造器与生命周期测试 |

--- a/docs/codex/CONFIG_RUNTIME_CAPABILITY_MATRIX.md
+++ b/docs/codex/CONFIG_RUNTIME_CAPABILITY_MATRIX.md
@@ -34,6 +34,10 @@
 | --- | --- | --- | --- |
 | Mode、event-stream Usage、Redis Stream、NATS JetStream | factory 创建 provider，ServiceContext 创建 EventStream/EventBridge | ServiceContext 终止型关闭 MQManager；Health/Publish/Subscribe 的 provider 调用受 Manager 读写门禁保护，Close 等待已进入调用并阻止新调用后再按稳定 registry key/name 顺序关闭去重实例；不支持关闭后复用 | supported |
 | 自定义 Provider | 通过 `RegisterProviderFactory` 注册后由 factory 创建；未注册名称是硬配置错误；测试注册必须用 `t.Cleanup` 调用 `UnregisterProviderFactory` 隔离全局状态 | MQManager/已注册 factory | supported |
+| `PublishOptions.OrderingKey` | 加性元数据；零值保持既有发布行为；`MQBridge` 将 `Envelope.ShardKey` 透传为 OrderingKey、`IdempotencyKey` 透传为 IdempotencyKey | MQProvider.Publish、Redis XAdd `ordering_key` 字段 | supported |
+| ordered-reliable 可选能力 | 显式 `ServiceContext`/`ServiceEventBridge.RequireOrderedReliableByShardKey` 或构造选项 + Ensure；未声明时零行为变化 | `OrderedReliableMQProvider`、`MQManager.RequireOrderedReliable`、空 ShardKey fail-closed、Outbox 同 key barrier | supported（可选） |
+| Redis Streams ordered-reliable | 单 active owner lease；读新消息前先 reclaim 旧 pending（MinIdle=0）；handler 丢 owner 不 ACK；SubscribeReliable 强制 Count=1 | `RedisStreamProvider`；真 Redis 测试需 `CORE_TEST_REDIS_ADDR`；发版前各 provider 应跑 `VerifyOrderedReliableFailureBarrier` | supported |
+| NATS JetStream ordered-reliable / `ReliableMQProvider` | 内建 NATS 仅普通 Publish/Subscribe；声明 ordered-reliable requirement 时 fail closed | 无完整 reliable/ordered owner | rejected（待实现） |
 | kafka、rabbitmq、rocketmq 内建 provider | 未注册同名自定义 factory 时 BuildManager 返回 not implemented | 无内建 owner | rejected |
 | transport/websocket/delayed-task Usage、request/reply、retry、dead-letter、dynamic switch | 启用时 Validate 明确失败；Enable=false 和预填默认参数只是 inactive/旧配置兼容 | 无 | rejected |
 | `Mode=off` 下的旧 MQ 字段 | 不创建 manager/provider/event bridge，保留旧配置解析兼容 | inactive，无生命周期对象 | rejected |

--- a/docs/codex/ORDERED_RELIABLE_MQ_CAPABILITY_REQUEST.md
+++ b/docs/codex/ORDERED_RELIABLE_MQ_CAPABILITY_REQUEST.md
@@ -301,8 +301,9 @@ go test ./pkg/server/mq/ -count=1 -run 'Conformance|OrderedReliable|FakeOrdered'
 CORE_TEST_REDIS_ADDR=127.0.0.1:6379 go test ./pkg/server/mq/ -count=1 -run RedisReliable
 ```
 
-handler 应在 owner lease TTL 内完成（默认约 `max(2m, 3×MinIdle)`）；
-超时后旧 owner 不得 ACK，新 owner 先回收 pending 再读新消息。
+handler 与**单次 pending 排空总时长**均应落在 owner lease TTL 内（默认约
+`max(2m, 3×MinIdle)`）。实现会在每条成功处理后 refresh lease；超时后旧 owner
+不得 ACK，新 owner 先回收 pending（MinIdle=0）再读新消息。
 
 ## 11. Bitzoom 迁移条件
 

--- a/docs/codex/ORDERED_RELIABLE_MQ_CAPABILITY_REQUEST.md
+++ b/docs/codex/ORDERED_RELIABLE_MQ_CAPABILITY_REQUEST.md
@@ -285,6 +285,25 @@ Core 现有 `redis-stream` provider 本身**不**等于上述 ordered-reliable �
 - release-contract、race、vet、format 门禁；
 - 正式版本发布说明。
 
+### 10.1 实现状态（对照 main，截至 residual 修复）
+
+已合入：API/透传/Require fail-closed、Outbox barrier（含可选 SkipBlocked）、
+Redis 单 owner + 读 `>` 前 reclaim pending（MinIdle=0）+ lost-owner 不 ACK、
+`VerifyOrderedReliableFailureBarrier`、能力矩阵与 API 兼容表面登记。
+
+发版门禁（每个生产 provider 必须通过，含自定义 factory）：
+
+```bash
+# 行为套件（fake 或真实 provider）
+go test ./pkg/server/mq/ -count=1 -run 'Conformance|OrderedReliable|FakeOrdered'
+
+# 真 Redis integration（需环境变量）
+CORE_TEST_REDIS_ADDR=127.0.0.1:6379 go test ./pkg/server/mq/ -count=1 -run RedisReliable
+```
+
+handler 应在 owner lease TTL 内完成（默认约 `max(2m, 3×MinIdle)`）；
+超时后旧 owner 不得 ACK，新 owner 先回收 pending 再读新消息。
+
 ## 11. Bitzoom 迁移条件
 
 Bitzoom 只有在以下条件**同时**满足后，才评估替换项目内 adapter：

--- a/pkg/server/mq/provider_redis.go
+++ b/pkg/server/mq/provider_redis.go
@@ -328,7 +328,11 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			}
 			continue
 		}
-		// 2) 接管后必须先回收其他 consumer 的 pending（MinIdle=0），再读新消息，
+		// 2) 仅仍为 owner 时 reclaim：防止 displaced owner 用 MinIdle=0 窃取新 owner 的 pending。
+		if !r.stillOwner(ctx, subject, options) {
+			continue
+		}
+		// 3) 接管后必须先回收其他 consumer 的 pending（MinIdle=0），再读新消息，
 		//    避免 failover 时 > 越过旧 owner 未 ACK 的消息导致越序。
 		if blocked := r.reclaimPending(ctx, key, subject, options, handler, 0); blocked {
 			if !r.stillOwner(ctx, subject, options) {
@@ -341,7 +345,7 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			}
 			continue
 		}
-		// 3) 读新消息前再次确认 owner。
+		// 4) 读新消息前再次确认 owner。
 		if !r.stillOwner(ctx, subject, options) {
 			continue
 		}
@@ -368,7 +372,7 @@ func (r *RedisStreamProvider) processOwnPending(
 	options ReliableSubscribeOptions,
 	handler func(*Message) error,
 ) bool {
-	// 连续排空 pending，成功路径不人为 sleep。
+	// 连续排空 pending；每条成功后在 handle 内 refreshOwner 续约，避免长 drain 丢 lease。
 	for {
 		entries, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
 			Group: options.Group, Consumer: options.Consumer,
@@ -406,6 +410,10 @@ func (r *RedisStreamProvider) reclaimPending(
 ) bool {
 	start := "0-0"
 	for {
+		// 长 reclaim 期间保持 lease，避免被 standby 抢占后仍继续 XAutoClaim。
+		if !r.refreshOwner(ctx, subject, options) {
+			return true
+		}
 		messages, next, err := r.client.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 			Stream: key, Group: options.Group, Consumer: options.Consumer,
 			MinIdle: minIdle, Start: start, Count: 1,
@@ -424,7 +432,7 @@ func (r *RedisStreamProvider) reclaimPending(
 }
 
 // handleReliableMessages 按序处理；任一条失败则停止后续（失败屏障），返回 true。
-// handler 成功后若已丢 owner（lease fencing），不 ACK，留给新 owner 重投，避免双写/越序。
+// handler 成功后：refreshOwner 续约并 fencing；已丢 owner 则不 ACK，留给新 owner 重投。
 func (r *RedisStreamProvider) handleReliableMessages(
 	ctx context.Context,
 	key, subject string,
@@ -450,8 +458,8 @@ func (r *RedisStreamProvider) handleReliableMessages(
 			)
 			return true
 		}
-		// fencing：handler 期间若 lease 过期被接管，禁止 ACK。
-		if !r.stillOwner(ctx, subject, options) {
+		// 续约 + fencing：长 drain 期间刷新 lease；若已被接管则禁止 ACK。
+		if !r.refreshOwner(ctx, subject, options) {
 			logx.Errorw("mq_redis_reliable_lost_owner_skip_ack",
 				logx.Field("subject", subject),
 				logx.Field("message_id", messageID),

--- a/pkg/server/mq/provider_redis.go
+++ b/pkg/server/mq/provider_redis.go
@@ -244,6 +244,15 @@ end
 return 0
 `)
 
+// 只读 fencing：不续约、不抢占，仅判断当前锁是否仍为本 consumer。
+var redisOwnerCheckScript = redis.NewScript(`
+local cur = redis.call("GET", KEYS[1])
+if cur == ARGV[1] then
+  return 1
+end
+return 0
+`)
+
 func (r *RedisStreamProvider) tryAcquireOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
 	ttl := ownerLeaseTTL(options)
 	ok, err := r.client.SetNX(ctx, r.ownerLockKey(subject, options.Group), options.Consumer, ttl).Result()
@@ -266,9 +275,14 @@ func (r *RedisStreamProvider) releaseOwner(ctx context.Context, subject string, 
 	_ = redisOwnerReleaseScript.Run(ctx, r.client, []string{lockKey}, options.Consumer).Err()
 }
 
-// stillOwner 在 handler 完成后做 fencing 检查：已丢 owner 则不得 ACK。
+// stillOwner 只读 fencing：已丢 owner 则不得 ACK。不续约、不抢占，避免与 refresh 语义混淆。
 func (r *RedisStreamProvider) stillOwner(ctx context.Context, subject string, options ReliableSubscribeOptions) bool {
-	return r.refreshOwner(ctx, subject, options)
+	lockKey := r.ownerLockKey(subject, options.Group)
+	n, err := redisOwnerCheckScript.Run(ctx, r.client, []string{lockKey}, options.Consumer).Int()
+	if err != nil {
+		return false
+	}
+	return n == 1
 }
 
 func (r *RedisStreamProvider) runReliableSubscriber(
@@ -286,8 +300,8 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			return
 		case <-ticker.C:
 			if r.refreshOwner(ctx, subject, options) {
-				// 仅 owner 认领超时 pending，避免多 active 并行越序。
-				if blocked := r.reclaimPending(ctx, key, subject, options, handler); blocked {
+				// 周期认领：MinIdle 控制，避免抢仍活跃的 in-flight。
+				if blocked := r.reclaimPending(ctx, key, subject, options, handler, options.MinIdle); blocked {
 					continue
 				}
 			}
@@ -301,7 +315,7 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			}
 			continue
 		}
-		// 先排空本 consumer 的 pending，失败则不读新消息（同 key / 同 stream 失败屏障）。
+		// 1) 先排空本 consumer 的 pending。
 		if blocked := r.processOwnPending(ctx, key, subject, options, handler); blocked {
 			// 仅失败时 backoff；成功排空 pending 不睡，避免 N×50ms 延迟税。
 			if !r.stillOwner(ctx, subject, options) {
@@ -314,7 +328,20 @@ func (r *RedisStreamProvider) runReliableSubscriber(
 			}
 			continue
 		}
-		// 读新消息前再次确认 owner，缩小双 active 窗口。
+		// 2) 接管后必须先回收其他 consumer 的 pending（MinIdle=0），再读新消息，
+		//    避免 failover 时 > 越过旧 owner 未 ACK 的消息导致越序。
+		if blocked := r.reclaimPending(ctx, key, subject, options, handler, 0); blocked {
+			if !r.stillOwner(ctx, subject, options) {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+		// 3) 读新消息前再次确认 owner。
 		if !r.stillOwner(ctx, subject, options) {
 			continue
 		}
@@ -366,18 +393,22 @@ func (r *RedisStreamProvider) processOwnPending(
 	}
 }
 
-// reclaimPending 认领超时 pending。返回 true 表示处理失败应阻断。
+// reclaimPending 认领其他 consumer 的 pending。
+// minIdle=0：接管后立即回收，防止 > 越过旧 owner 未 ACK 消息；
+// minIdle=options.MinIdle：周期回收，给崩溃实例一点宽限。
+// 返回 true 表示处理失败应阻断新消息。
 func (r *RedisStreamProvider) reclaimPending(
 	ctx context.Context,
 	key, subject string,
 	options ReliableSubscribeOptions,
 	handler func(*Message) error,
+	minIdle time.Duration,
 ) bool {
 	start := "0-0"
 	for {
 		messages, next, err := r.client.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 			Stream: key, Group: options.Group, Consumer: options.Consumer,
-			MinIdle: options.MinIdle, Start: start, Count: 1,
+			MinIdle: minIdle, Start: start, Count: 1,
 		}).Result()
 		if err != nil || len(messages) == 0 {
 			return false

--- a/pkg/server/mq/provider_redis_reliable_test.go
+++ b/pkg/server/mq/provider_redis_reliable_test.go
@@ -84,3 +84,83 @@ func TestRedisReliableSubscriptionReclaimsFailedPendingMessage(t *testing.T) {
 		t.Fatal("失败的 Redis pending 消息未被重新认领")
 	}
 }
+
+// TestRedisReliableTakeoverPreservesOrderAcrossMultiplePending 锁定：
+// owner A 失败阻断后留下多条 pending，B 接管后必须先排空 pending 再处理新消息，不得越序。
+func TestRedisReliableTakeoverPreservesOrderAcrossMultiplePending(t *testing.T) {
+	provider := newReliableRedisProvider(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const total = 20
+	var (
+		aStarted  = make(chan struct{}, 1)
+		aConsumer = "owner-a"
+		bConsumer = "owner-b"
+		group     = "positions-takeover"
+		subject   = "trade.fills"
+	)
+
+	// A：全部失败，1..10 进入 PEL；不 ACK。
+	firstCancel, err := provider.SubscribeReliable(ctx, subject, mq.ReliableSubscribeOptions{
+		Group: group, Consumer: aConsumer, MinIdle: 30 * time.Millisecond, ClaimInterval: 20 * time.Millisecond,
+	}, func(message *mq.Message) error {
+		select {
+		case aStarted <- struct{}{}:
+		default:
+		}
+		return errors.New("a blocked")
+	})
+	require.NoError(t, err)
+
+	for i := 1; i <= 10; i++ {
+		body := fmt.Sprintf("%02d", i)
+		require.NoError(t, provider.Publish(ctx, subject, []byte(body), &mq.PublishOptions{
+			OrderingKey: "market-a", IdempotencyKey: body,
+		}))
+	}
+	select {
+	case <-aStarted:
+	case <-ctx.Done():
+		t.Fatal("owner A 未开始消费")
+	}
+	time.Sleep(300 * time.Millisecond)
+	firstCancel()
+
+	// A 退出后再发 11..20；B 接管后应先 01..10 再 11..20。
+	for i := 11; i <= total; i++ {
+		body := fmt.Sprintf("%02d", i)
+		require.NoError(t, provider.Publish(ctx, subject, []byte(body), &mq.PublishOptions{
+			OrderingKey: "market-a", IdempotencyKey: body,
+		}))
+	}
+
+	got := make([]string, 0, total)
+	done := make(chan struct{})
+	secondCancel, err := provider.SubscribeReliable(ctx, subject, mq.ReliableSubscribeOptions{
+		Group: group, Consumer: bConsumer, MinIdle: 30 * time.Millisecond, ClaimInterval: 20 * time.Millisecond,
+	}, func(message *mq.Message) error {
+		got = append(got, string(message.Data))
+		if len(got) >= total {
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	defer secondCancel()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("timeout got=%v (len=%d)", got, len(got))
+	}
+
+	require.Equal(t, total, len(got), "got=%v", got)
+	for i := 0; i < total; i++ {
+		require.Equal(t, fmt.Sprintf("%02d", i+1), got[i], "full=%v", got)
+	}
+}

--- a/pkg/server/mq/provider_redis_reliable_test.go
+++ b/pkg/server/mq/provider_redis_reliable_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitalwayhk/core/pkg/server/mq"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +20,18 @@ func newReliableRedisProvider(t *testing.T) *mq.RedisStreamProvider {
 		t.Skip("设置 CORE_TEST_REDIS_ADDR 后运行 Redis Streams 可靠订阅测试")
 	}
 	provider := mq.NewRedisStreamProvider(addr, fmt.Sprintf("core:test:event:%d", time.Now().UnixNano()), 0)
+	require.NoError(t, provider.Connect(context.Background()))
+	t.Cleanup(func() { require.NoError(t, provider.Close()) })
+	return provider
+}
+
+func newReliableRedisProviderWithPrefix(t *testing.T, prefix string) *mq.RedisStreamProvider {
+	t.Helper()
+	addr := os.Getenv("CORE_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("设置 CORE_TEST_REDIS_ADDR 后运行 Redis Streams 可靠订阅测试")
+	}
+	provider := mq.NewRedisStreamProvider(addr, prefix, 0)
 	require.NoError(t, provider.Connect(context.Background()))
 	t.Cleanup(func() { require.NoError(t, provider.Close()) })
 	return provider
@@ -86,49 +99,46 @@ func TestRedisReliableSubscriptionReclaimsFailedPendingMessage(t *testing.T) {
 }
 
 // TestRedisReliableTakeoverPreservesOrderAcrossMultiplePending 锁定：
-// owner A 失败阻断后留下多条 pending，B 接管后必须先排空 pending 再处理新消息，不得越序。
+// loader 将 01..10 读入 PEL 后不 ACK（多 pending）；B 接管后必须先排空 pending 再处理 11..20。
 func TestRedisReliableTakeoverPreservesOrderAcrossMultiplePending(t *testing.T) {
-	provider := newReliableRedisProvider(t)
+	addr := os.Getenv("CORE_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("设置 CORE_TEST_REDIS_ADDR 后运行 Redis Streams 可靠订阅测试")
+	}
+	prefix := fmt.Sprintf("core:test:takeover:%d", time.Now().UnixNano())
+	provider := newReliableRedisProviderWithPrefix(t, prefix)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	const total = 20
-	var (
-		aStarted  = make(chan struct{}, 1)
-		aConsumer = "owner-a"
-		bConsumer = "owner-b"
-		group     = "positions-takeover"
-		subject   = "trade.fills"
-	)
+	const pendingN = 10
+	group := "positions-takeover"
+	subject := "trade.fills"
+	streamKey := prefix + ":" + subject
+	loader := "loader-crash"
 
-	// A：全部失败，1..10 进入 PEL；不 ACK。
-	firstCancel, err := provider.SubscribeReliable(ctx, subject, mq.ReliableSubscribeOptions{
-		Group: group, Consumer: aConsumer, MinIdle: 30 * time.Millisecond, ClaimInterval: 20 * time.Millisecond,
-	}, func(message *mq.Message) error {
-		select {
-		case aStarted <- struct{}{}:
-		default:
-		}
-		return errors.New("a blocked")
-	})
-	require.NoError(t, err)
-
-	for i := 1; i <= 10; i++ {
+	// 用原始 Redis 把 01..10 读进 loader 的 PEL（不 ACK），构造真正多 pending。
+	raw := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { _ = raw.Close() })
+	require.NoError(t, raw.XGroupCreateMkStream(ctx, streamKey, group, "0").Err())
+	for i := 1; i <= pendingN; i++ {
 		body := fmt.Sprintf("%02d", i)
-		require.NoError(t, provider.Publish(ctx, subject, []byte(body), &mq.PublishOptions{
-			OrderingKey: "market-a", IdempotencyKey: body,
-		}))
+		require.NoError(t, raw.XAdd(ctx, &redis.XAddArgs{
+			Stream: streamKey,
+			Values: map[string]interface{}{
+				"data": body, "ordering_key": "market-a", "idempotency_key": body,
+			},
+		}).Err())
 	}
-	select {
-	case <-aStarted:
-	case <-ctx.Done():
-		t.Fatal("owner A 未开始消费")
-	}
-	time.Sleep(300 * time.Millisecond)
-	firstCancel()
+	entries, err := raw.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group: group, Consumer: loader, Streams: []string{streamKey, ">"}, Count: int64(pendingN), Block: time.Second,
+	}).Result()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Len(t, entries[0].Messages, pendingN)
 
-	// A 退出后再发 11..20；B 接管后应先 01..10 再 11..20。
-	for i := 11; i <= total; i++ {
+	// 再发 11..20 作为「新消息」；B 必须先 reclaim 01..10 再读新。
+	for i := pendingN + 1; i <= total; i++ {
 		body := fmt.Sprintf("%02d", i)
 		require.NoError(t, provider.Publish(ctx, subject, []byte(body), &mq.PublishOptions{
 			OrderingKey: "market-a", IdempotencyKey: body,
@@ -138,7 +148,7 @@ func TestRedisReliableTakeoverPreservesOrderAcrossMultiplePending(t *testing.T) 
 	got := make([]string, 0, total)
 	done := make(chan struct{})
 	secondCancel, err := provider.SubscribeReliable(ctx, subject, mq.ReliableSubscribeOptions{
-		Group: group, Consumer: bConsumer, MinIdle: 30 * time.Millisecond, ClaimInterval: 20 * time.Millisecond,
+		Group: group, Consumer: "owner-b", MinIdle: 30 * time.Millisecond, ClaimInterval: 20 * time.Millisecond,
 	}, func(message *mq.Message) error {
 		got = append(got, string(message.Data))
 		if len(got) >= total {


### PR DESCRIPTION
## 背景

外部复审 PR #6 结论 MERGE_WITH_NITS，本 PR 关闭 residual：

1. 新 owner 读 > 前先 reclaim 旧 pending（MinIdle=0），避免 failover 越序
2. 真 Redis 双实例多消息接管保序 integration
3. stillOwner 只读 fencing 与 refresh 分离
4. compat / matrix / 能力请求发版门禁文档

## 验证

```bash
go test ./pkg/server/mq/ ./pkg/server/event/ ./pkg/server/router/ -count=1
CORE_TEST_REDIS_ADDR=127.0.0.1:6379 go test ./pkg/server/mq/ -count=1 -run RedisReliable
```
